### PR TITLE
docs(readme): correct stale stats, schema, and visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # Internship Outreach - Email Database
-Private repository containing all scraped company emails and HR contacts for paid internship outreach.
+Public repository containing scraped company emails and HR contacts for paid internship outreach.
 Designed to streamline internship outreach by combining verified contact data with automated career-page monitoring for faster application opportunities.
 ## Files
 
-- `emails.csv` — 198 companies with general contact emails, categories, priority levels
-- `hr_contacts.csv` — 53 named HR/TA/founder contacts with direct emails and LinkedIn profiles
+- `emails.csv` — 402 companies with general contact emails, categories, priority levels
+- `hr_contacts.csv` — 1,305 named HR/TA/founder contacts with direct emails and LinkedIn profiles
 - `make_sheet.py` — Python script to generate formatted Excel spreadsheet
 
 ## Stats
 
-- **198** companies (Dubai/UAE + Gandhinagar/GIFT City/Infocity)
-- **53** named HR contacts with direct emails
+- **402** companies (Dubai/UAE, Gandhinagar/GIFT City, and pan-India)
+- **1,305** named HR contacts with direct emails
 - **~130** High-priority targets
 - **~25** verified direct HR/careers/recruitment inboxes
 
@@ -19,6 +19,7 @@ Designed to streamline internship outreach by combining verified contact data wi
 - **Rounds 1-3**: Dubai/UAE tech companies (#1-143)
 - **Rounds 4-8**: GIFT City, Infocity, Kudasan, Sargasan, Gandhinagar (#144-191)
 - **Round 9**: PDPU corridor, Infocity expansion, Arrow/eInfochips (#192-198)
+- **Round 10+**: pan-India expansion — Bengaluru, Hyderabad, Pune, Jaipur, Lucknow, Kota, and other metros (see `city_*.csv` batches)
 
 ## Categories
 
@@ -41,7 +42,7 @@ Generates `Dubai_Internship_Outreach.xlsx` with 4 sheets:
 
 Monitors company career pages and alerts when **new postings** appear.
 
-- `career_pages.csv` — pages to watch (`Company, URL, Notes`)
+- `career_pages.csv` — pages to watch (`Company, URL, Location, EntryLevel, Notes`)
 - `career_watch.py` — fetches each page, extracts job-like entries, diffs vs `career_state.json`, writes new entries to `career_alerts.md` / `career_alerts.log`
 - `.github/workflows/career-watch.yml` — runs every 12h, opens a GitHub **issue** on new entries, commits updated state
 


### PR DESCRIPTION
## Summary

The `README.md` had drifted out of sync with the actual repository contents and metadata. This PR corrects the stale figures, the `career_pages.csv` schema, and the repo-visibility wording so the docs match reality. No code or data changes — documentation only.

## What changed

| Claim in README | Reality | Fixed to |
|---|---|---|
| "**Private** repository" | Repo is public | "Public repository" |
| `emails.csv` — **198** companies | 402 data rows | 402 |
| `hr_contacts.csv` — **53** contacts | 1,305 data rows | 1,305 |
| `career_pages.csv` cols = `Company, URL, Notes` | actual header = `Company, URL, Location, EntryLevel, Notes` | corrected + matches the schema already listed later in the same README |
| Regions = Dubai/UAE + Gandhinagar only | data now spans Bengaluru, Hyderabad, Pune, Jaipur, Lucknow, Kota, etc. (`city_*.csv`) | added a "Round 10+: pan-India expansion" line |

## How it was verified

Row counts were read directly from the CSVs with `csv.DictReader`, and the `career_pages.csv` header was read from the file. The public visibility is self-evident (the repo clones anonymously).

## Testing

Documentation-only change; rendered and reviewed the Markdown locally. No scripts affected.
