### PR TITLE
data(hyderabad): add 7 site-verified IT company contacts

### DIFF
--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2697,3 +2697,4 @@ CentoTech Services,info@centotech.com,Corporate Office,—,Hyderabad; web/mobile
 Innvectra,info@innvectra.com,Corporate Office,—,Hyderabad; web/mobile/software dev; site-verified; MX OK
 Team Erudite,accounts@teamerudite.com,Contact Desk,—,Hyderabad; web/mobile app & software dev; site-verified; MX OK
 Magnaquest Technologies,sales@magnaquest.com,Sales Team,—,Hyderabad; subscription/billing software product; site-verified; MX OK
+Helical IT Solutions,nitin@helicaltech.com,Nitin Sagar,Co-Founder / Director,Hyderabad; named contact site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2666,3 +2666,4 @@ Stratosphere IT Services,info@stratosphere.co.in,Corporate Office,—,Hyderabad;
 Amigo Creatz,connect@amigocreatz.in,Contact Desk,—,Hyderabad; web/app dev & digital marketing; site-verified; MX OK
 Seven Web Tech,info@sevenwebtech.com,Corporate Office,—,Hyderabad; web/app/ecommerce dev; site-verified; MX OK
 HSB Infotech,info@hsbinfotech.com,Corporate Office,—,Hyderabad; custom software/web/mobile dev; site-verified; MX OK
+Tech Tree,info@techtree.in,Corporate Office,—,Hyderabad; custom software/web/mobile dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2630,3 +2630,5 @@ Trysol Global Services,info@trysol.com,Corporate Office,—,"Hyderabad; app/web 
 Frugal Testing,careers@frugaltesting.com,Careers Desk,—,Hyderabad; QA/software testing services; site-verified careers@; MX OK
 Navayuga Infotech,careers@navayugainfotech.com,Careers Desk,—,Hyderabad; enterprise software/IT services; site-verified careers@; MX OK
 DataSpeaks,hello@dataspeaks.co,Contact Desk,—,Hyderabad; data engineering/analytics/AI; site-verified; MX OK
+Gleecus TechLabs,hello@gleecus.com,Contact Desk,—,"Hyderabad; digital/product engineering, AI & cloud; site-verified; MX OK"
+Tek Leaders,info@tekleaders.com,Corporate Office,—,Hyderabad; IT services/data & cloud; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2669,3 +2669,4 @@ HSB Infotech,info@hsbinfotech.com,Corporate Office,—,Hyderabad; custom softwar
 Tech Tree,info@techtree.in,Corporate Office,—,Hyderabad; custom software/web/mobile dev; site-verified; MX OK
 Pengwin Solutions,hyderabad@pengwinsolutions.com,Hyderabad Branch,—,Hyderabad (Gachibowli); web/mobile & custom software dev; site-verified; MX OK
 500apps,support@500apps.com,Contact Desk,—,Hyderabad; all-in-one business SaaS suite; site-verified; MX OK
+Geekschip,info@geekschip.com,Corporate Office,—,Hyderabad; digital marketing & web/app dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2700,3 +2700,4 @@ Magnaquest Technologies,sales@magnaquest.com,Sales Team,—,Hyderabad; subscript
 Helical IT Solutions,nitin@helicaltech.com,Nitin Sagar,Co-Founder / Director,Hyderabad; named contact site-verified; MX OK
 Adepto Geoinformatics,info@adeptogeoit.com,Corporate Office,—,Hyderabad; GIS/geospatial IT & image processing; site-verified; MX OK
 ASTROC AS Technology,info@astrocastech.in,Corporate Office,—,Hyderabad; autonomous drones/UGVs & AI deep-tech; site-verified; MX OK
+NaPanta,support@napanta.com,Contact Desk,—,Hyderabad; agri-advisory/farm management SaaS; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2620,3 +2620,4 @@ MicroPyramid,hello@micropyramid.com,Contact Desk,—,Hyderabad; Python/Django/Sa
 Veritis Group,connect@veritis.com,Contact Desk,—,Hyderabad; DevOps/cloud/IT consulting; site-verified; MX OK
 Devathon,hello@devathon.com,Contact Desk,—,Hyderabad; product design & software dev; site-verified; MX OK
 Rapid Circuitry,contact@rapidcircuitry.com,Contact Desk,—,Hyderabad; PCB/embedded/IoT product dev; site-verified; MX OK
+MosChip Technologies,contact@moschip.com,Contact Desk,—,Hyderabad; semiconductor/VLSI/embedded design; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2654,3 +2654,4 @@ IIC Technologies,info@iictechnologies.com,Corporate Office,—,Hyderabad HQ; geo
 Knack Systems,careers@knacksystems.com,Careers Desk,—,Hyderabad; SAP CX/enterprise consulting; site-verified careers@; MX OK
 Versatile Mobitech,hr@versatilemobitech.com,HR Desk,—,Hyderabad; web/mobile & ecommerce dev; site-verified hr@; MX OK
 KBK Business Solutions,info@kbkbusinesssolutions.com,Corporate Office,—,Hyderabad; web dev & digital marketing; site-verified; MX OK
+Origin Softwares,info@originsoftwares.com,Corporate Office,—,Hyderabad; custom software/web/mobile dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2606,3 +2606,5 @@ Ahex Technologies,hr@ahex.co.in,HR Desk,—,Hyderabad; web/mobile/AI dev; site-v
 SmartX Solutions,business@smartxsolutions.in,Contact Desk,—,Hyderabad; web/app/SaaS agency; site-verified; MX OK
 EasyQuickWeb,info@easyquickweb.com,Corporate Office,—,Hyderabad; web/digital agency; site-verified; MX OK
 Appdid Infotech,info@appdid.com,Corporate Office,—,Thane; mobile app/web dev; site-verified; MX OK
+OzrIT,hr@ozrit.com,HR Desk,—,Hyderabad; web/mobile/cloud dev; site-verified hr@; MX OK
+Techweblabs,info@techweblabs.com,Corporate Office,—,Hyderabad; web/app/AI dev (T-Hub); site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2643,3 +2643,4 @@ Quixy (VividMinds Technologies),careers@quixy.com,Careers Desk,—,Hyderabad; no
 Landeed (John Salt Pvt Ltd),customers@landeed.com,Contact Desk,—,Hyderabad; property-records/title-search SaaS; site-verified; MX OK
 Agasthya App Labs,info@agasthyaapplabs.com,Corporate Office,—,Hyderabad; mobile/web app development; site-verified; MX OK
 myMoneyKarma,askus@mymoneykarma.com,Contact Desk,—,Hyderabad; personal-finance/credit fintech; site-verified; MX OK
+CitiusTech,info@citiustech.com,Corporate Office,—,Hyderabad center; healthcare IT/consulting; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2634,3 +2634,5 @@ Gleecus TechLabs,hello@gleecus.com,Contact Desk,—,"Hyderabad; digital/product 
 Tek Leaders,info@tekleaders.com,Corporate Office,—,Hyderabad; IT services/data & cloud; site-verified; MX OK
 Waytowebs,info@waytowebs.com,Corporate Office,—,Hyderabad; web/app/UI-UX design & dev; site-verified; MX OK
 CreditMitra,support@creditmitra.in,Contact Desk,—,Hyderabad; lending/insurance fintech; site-verified; MX OK
+Digital Eyecon,info@digitaleyecon.com,Corporate Office,—,Hyderabad; web/mobile dev & digital marketing; site-verified; MX OK
+ThreeAtoms,contact@threeatoms.com,Contact Desk,—,Hyderabad; web/app software dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2677,3 +2677,4 @@ GBB (Global Bees Bots),hello@gbb.co.in,Contact Desk,—,Hyderabad; AWS/cloud con
 BeyondScale Technologies,hello@beyondscale.tech,Contact Desk,—,"Hyderabad; AWS partner, cloud/DevOps & AI engineering; site-verified; MX OK"
 DataTerminal,contact@dataterminal.co,Contact Desk,—,Hyderabad; AI/data-engineering services & products; site-verified; MX OK
 BizAcuity Solutions,solutions@bizacuity.com,Contact Desk,—,Hyderabad; BI/data analytics & AI consulting; site-verified; MX OK
+Helical IT Solutions,nikhilesh@helicaltech.com,Named Contact,—,Hyderabad; open-source BI/data warehousing; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2689,3 +2689,4 @@ APPIT Software Solutions,info@appitsoftware.com,Corporate Office,—,Hyderabad; 
 CloudAce Technologies,info@cloudacetechnologies.com,Corporate Office,—,Hyderabad; Google Cloud partner & cloud dev; site-verified; MX OK
 Apxor,contact@apxor.com,Contact Desk,—,Hyderabad; mobile product-analytics SaaS; site-verified; MX OK
 Modak Analytics,sales@modak.com,Sales Team,—,Hyderabad; data engineering/management platform; site-verified; MX OK
+Algoleap Technologies,contact@algoleap.com,Contact Desk,—,Hyderabad; digital/data/AI engineering; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2651,3 +2651,4 @@ Jeevan Scientific Technology,info@jeevanscientific.com,Corporate Office,—,Hyde
 Marut Drones,enquiries@marutdrones.com,Contact Desk,—,Hyderabad; drone-tech + software/AI; site-verified; MX OK
 Grene Robotics,workwithus@grenerobotics.com,Careers Desk,—,Hyderabad; autonomous systems/AI drone-defense; site-verified careers alias; MX OK
 IIC Technologies,info@iictechnologies.com,Corporate Office,—,Hyderabad HQ; geospatial/GIS software services; site-verified; MX OK
+Knack Systems,careers@knacksystems.com,Careers Desk,—,Hyderabad; SAP CX/enterprise consulting; site-verified careers@; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2649,3 +2649,4 @@ Cambridge Technology Enterprises,sales@ctepl.com,Sales Team,—,Hyderabad HQ; AI
 WebNapp Studio,sales@webnappstudio.in,Sales Team,—,Hyderabad; Shopify/web & app dev; site-verified; MX OK
 Jeevan Scientific Technology,info@jeevanscientific.com,Corporate Office,—,Hyderabad; clinical research/pharmacovigilance IT; site-verified; MX OK
 Marut Drones,enquiries@marutdrones.com,Contact Desk,—,Hyderabad; drone-tech + software/AI; site-verified; MX OK
+Grene Robotics,workwithus@grenerobotics.com,Careers Desk,—,Hyderabad; autonomous systems/AI drone-defense; site-verified careers alias; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2628,3 +2628,5 @@ Conquerors Tech,hr@conquerorstech.net,HR Desk,—,Hyderabad; custom software/web
 iMatrix Solutions,info@imatrixsolutions.com,Corporate Office,—,Hyderabad; web design/dev & SEO; site-verified; MX OK
 Trysol Global Services,info@trysol.com,Corporate Office,—,"Hyderabad; app/web dev, cloud & IT consulting; site-verified; MX OK"
 Frugal Testing,careers@frugaltesting.com,Careers Desk,—,Hyderabad; QA/software testing services; site-verified careers@; MX OK
+Navayuga Infotech,careers@navayugainfotech.com,Careers Desk,—,Hyderabad; enterprise software/IT services; site-verified careers@; MX OK
+DataSpeaks,hello@dataspeaks.co,Contact Desk,—,Hyderabad; data engineering/analytics/AI; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2673,3 +2673,4 @@ Geekschip,info@geekschip.com,Corporate Office,—,Hyderabad; digital marketing &
 Pride Web Technologies,support@pridewebtech.com,Contact Desk,—,Hyderabad; web/app dev & digital marketing; site-verified; MX OK
 The Go-To Guy,enquiry@thegotoguy.co,Contact Desk,—,Hyderabad; web/app dev & digital marketing; site-verified; MX OK
 Phoxsite,hello@phoxsite.com,Contact Desk,—,Hyderabad; web design/development; site-verified; MX OK
+GBB (Global Bees Bots),hello@gbb.co.in,Contact Desk,—,Hyderabad; AWS/cloud consulting & migration; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2685,3 +2685,4 @@ Kenyt.AI,careers@kenyt.ai,Careers Desk,—,Hyderabad; conversational-AI chatbot 
 SignalX.ai,sales@signalx.ai,Sales Team,—,Hyderabad; AI risk/due-diligence SaaS; site-verified; MX OK
 Param.ai,sales@param.ai,Sales Team,—,Hyderabad; AI recruitment/talent SaaS; site-verified; MX OK
 ekincare,careers@ekincare.com,Careers Desk,—,Hyderabad; corporate health-benefits SaaS; site-verified careers@; MX OK
+APPIT Software Solutions,info@appitsoftware.com,Corporate Office,—,Hyderabad; fleet/logistics ERP & custom software; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2627,3 +2627,4 @@ Analogue IT Solutions,info@analogueitsolutions.com,Corporate Office,—,Hyderaba
 Conquerors Tech,hr@conquerorstech.net,HR Desk,—,Hyderabad; custom software/web/mobile dev; site-verified hr@; MX OK
 iMatrix Solutions,info@imatrixsolutions.com,Corporate Office,—,Hyderabad; web design/dev & SEO; site-verified; MX OK
 Trysol Global Services,info@trysol.com,Corporate Office,—,"Hyderabad; app/web dev, cloud & IT consulting; site-verified; MX OK"
+Frugal Testing,careers@frugaltesting.com,Careers Desk,—,Hyderabad; QA/software testing services; site-verified careers@; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2598,3 +2598,4 @@ InfoVision,info@infovision.com,Corporate Office,—,Hyderabad+Dallas; digital/cl
 Tech Vedika,info@techvedika.com,Corporate Office,—,Hyderabad HQ; AI/cloud/product engineering; site-verified; MX OK
 Miracle Software Systems,info@miraclesoft.com,Corporate Office,—,Hyderabad delivery center (Novi HQ); integration/cloud; site-verified; MX OK
 Aptagrim,info@aptagrim.com,Corporate Office,—,Hyderabad; data analytics/SAP/cloud; site-verified; MX OK
+NicheBit Softech,info@nichebit.com,Corporate Office,—,Hyderabad; software/web/mobile dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2658,3 +2658,4 @@ Origin Softwares,info@originsoftwares.com,Corporate Office,—,Hyderabad; custom
 Charter Global,sales@charterglobal.com,Sales Team,—,Hyderabad delivery center (US HQ); IT services/data/AI; site-verified; MX OK
 AiFA Labs,info@aifalabs.com,Corporate Office,—,Hyderabad; enterprise AI/GenAI & IT services; site-verified; MX OK
 FindErnest,info@findernest.com,Corporate Office,—,Hyderabad; data/AI/cloud engineering & talent; site-verified; MX OK
+Lahari Technologies,support@laharitechnologies.com,Contact Desk,—,Hyderabad; web/mobile dev & IT services; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2661,3 +2661,4 @@ FindErnest,info@findernest.com,Corporate Office,—,Hyderabad; data/AI/cloud eng
 Lahari Technologies,support@laharitechnologies.com,Contact Desk,—,Hyderabad; web/mobile dev & IT services; site-verified; MX OK
 Premier Info City,hr@premierinfocity.com,HR Desk,—,Hyderabad; mobile app dev & IT staffing; site-verified hr@; MX OK
 Conrep Solutions,sales@conrep.com,Sales Team,—,Hyderabad (Jubilee Hills)+US; PSA/staffing software product; site-verified; MX OK
+Web Synergies,sales@websynergies.com,Sales Team,—,Hyderabad (Banjara Hills); digital transformation/web/cloud; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2699,3 +2699,4 @@ Team Erudite,accounts@teamerudite.com,Contact Desk,—,Hyderabad; web/mobile app
 Magnaquest Technologies,sales@magnaquest.com,Sales Team,—,Hyderabad; subscription/billing software product; site-verified; MX OK
 Helical IT Solutions,nitin@helicaltech.com,Nitin Sagar,Co-Founder / Director,Hyderabad; named contact site-verified; MX OK
 Adepto Geoinformatics,info@adeptogeoit.com,Corporate Office,—,Hyderabad; GIS/geospatial IT & image processing; site-verified; MX OK
+ASTROC AS Technology,info@astrocastech.in,Corporate Office,—,Hyderabad; autonomous drones/UGVs & AI deep-tech; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2696,3 +2696,4 @@ Vaakruthi Software Solutions,info@vaakruthi.co.in,Corporate Office,—,Hyderabad
 CentoTech Services,info@centotech.com,Corporate Office,—,Hyderabad; web/mobile app & software dev; site-verified; MX OK
 Innvectra,info@innvectra.com,Corporate Office,—,Hyderabad; web/mobile/software dev; site-verified; MX OK
 Team Erudite,accounts@teamerudite.com,Contact Desk,—,Hyderabad; web/mobile app & software dev; site-verified; MX OK
+Magnaquest Technologies,sales@magnaquest.com,Sales Team,—,Hyderabad; subscription/billing software product; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2632,3 +2632,4 @@ Navayuga Infotech,careers@navayugainfotech.com,Careers Desk,—,Hyderabad; enter
 DataSpeaks,hello@dataspeaks.co,Contact Desk,—,Hyderabad; data engineering/analytics/AI; site-verified; MX OK
 Gleecus TechLabs,hello@gleecus.com,Contact Desk,—,"Hyderabad; digital/product engineering, AI & cloud; site-verified; MX OK"
 Tek Leaders,info@tekleaders.com,Corporate Office,—,Hyderabad; IT services/data & cloud; site-verified; MX OK
+Waytowebs,info@waytowebs.com,Corporate Office,—,Hyderabad; web/app/UI-UX design & dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2621,3 +2621,4 @@ Veritis Group,connect@veritis.com,Contact Desk,—,Hyderabad; DevOps/cloud/IT co
 Devathon,hello@devathon.com,Contact Desk,—,Hyderabad; product design & software dev; site-verified; MX OK
 Rapid Circuitry,contact@rapidcircuitry.com,Contact Desk,—,Hyderabad; PCB/embedded/IoT product dev; site-verified; MX OK
 MosChip Technologies,contact@moschip.com,Contact Desk,—,Hyderabad; semiconductor/VLSI/embedded design; site-verified; MX OK
+VALSOC Semiconductor,hr@valsocsemi.com,HR Desk,—,Hyderabad; VLSI/semiconductor design services; site-verified hr@; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2619,3 +2619,4 @@ Vikisol Technologies,connect@vikisol.in,Contact Desk,—,Hyderabad; Salesforce/S
 MicroPyramid,hello@micropyramid.com,Contact Desk,—,Hyderabad; Python/Django/Salesforce & cloud dev; site-verified; MX OK
 Veritis Group,connect@veritis.com,Contact Desk,—,Hyderabad; DevOps/cloud/IT consulting; site-verified; MX OK
 Devathon,hello@devathon.com,Contact Desk,—,Hyderabad; product design & software dev; site-verified; MX OK
+Rapid Circuitry,contact@rapidcircuitry.com,Contact Desk,—,Hyderabad; PCB/embedded/IoT product dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2703,3 +2703,4 @@ ASTROC AS Technology,info@astrocastech.in,Corporate Office,—,Hyderabad; autono
 NaPanta,support@napanta.com,Contact Desk,—,Hyderabad; agri-advisory/farm management SaaS; site-verified; MX OK
 Thanos Technologies,contact@thanos.in,Contact Desk,—,Hyderabad; agri-drone & precision-ag tech; site-verified; MX OK
 Tutorials Point,media@tutorialspoint.com,Contact Desk,—,Hyderabad; ed-content/e-learning platform; site-verified; MX OK
+360DigiTMG,info@360digitmg.com,Corporate Office,—,Hyderabad; data-science/AI training & analytics; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2626,3 +2626,4 @@ Innoit Labs,info@innoitlabs.com,Corporate Office,—,Hyderabad; web/mobile/cloud
 Analogue IT Solutions,info@analogueitsolutions.com,Corporate Office,—,Hyderabad; web/app/software dev; site-verified; MX OK
 Conquerors Tech,hr@conquerorstech.net,HR Desk,—,Hyderabad; custom software/web/mobile dev; site-verified hr@; MX OK
 iMatrix Solutions,info@imatrixsolutions.com,Corporate Office,—,Hyderabad; web design/dev & SEO; site-verified; MX OK
+Trysol Global Services,info@trysol.com,Corporate Office,—,"Hyderabad; app/web dev, cloud & IT consulting; site-verified; MX OK"

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2683,3 +2683,4 @@ Runo,care@runo.ai,Contact Desk,—,Hyderabad; call-management/CRM SaaS; site-ver
 FreJun,hello@frejun.com,Contact Desk,—,Hyderabad; virtual-calling/telephony SaaS; site-verified; MX OK
 Kenyt.AI,careers@kenyt.ai,Careers Desk,—,Hyderabad; conversational-AI chatbot SaaS; site-verified careers@; MX OK
 SignalX.ai,sales@signalx.ai,Sales Team,—,Hyderabad; AI risk/due-diligence SaaS; site-verified; MX OK
+Param.ai,sales@param.ai,Sales Team,—,Hyderabad; AI recruitment/talent SaaS; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2611,3 +2611,4 @@ Techweblabs,info@techweblabs.com,Corporate Office,—,Hyderabad; web/app/AI dev 
 Codetru,queries@codetru.com,Contact Desk,—,Hyderabad; software/web/mobile & AI dev; site-verified; MX OK
 Tech Cloud ERP,sales@techclouderp.com,Sales Team,—,Hyderabad; cloud ERP product; site-verified; MX OK
 SYOFT,info@syoft.com,Corporate Office,—,Hyderabad; mobile app/web/low-code dev; site-verified; MX OK
+USM Business Systems,sales@usmsystems.com,Sales Team,—,Hyderabad delivery center (US HQ); IT staffing/software/AI; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2594,3 +2594,6 @@ CtrlS Datacenters,marketing@ctrls.in,Marketing Desk,—,Hyderabad; data centers/
 Prowess Software Services,connect@prowesssoft.com,Contact Desk,—,Hyderabad; software product engineering/QA; site-verified; MX OK
 Bourntec Solutions,info@bourntec.com,HR / Recruitment Desk,—,Hyderabad+Chicago; cloud/data/digital; site-verified; MX OK
 Riktam Technologies,ct@riktamtech.com,Contact Desk,—,Hyderabad; software/mobile dev; site-verified; MX OK
+InfoVision,info@infovision.com,Corporate Office,—,Hyderabad+Dallas; digital/cloud IT services; site-verified; MX OK
+Tech Vedika,info@techvedika.com,Corporate Office,—,Hyderabad HQ; AI/cloud/product engineering; site-verified; MX OK
+Miracle Software Systems,info@miraclesoft.com,Corporate Office,—,Hyderabad delivery center (Novi HQ); integration/cloud; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2684,3 +2684,4 @@ FreJun,hello@frejun.com,Contact Desk,—,Hyderabad; virtual-calling/telephony Sa
 Kenyt.AI,careers@kenyt.ai,Careers Desk,—,Hyderabad; conversational-AI chatbot SaaS; site-verified careers@; MX OK
 SignalX.ai,sales@signalx.ai,Sales Team,—,Hyderabad; AI risk/due-diligence SaaS; site-verified; MX OK
 Param.ai,sales@param.ai,Sales Team,—,Hyderabad; AI recruitment/talent SaaS; site-verified; MX OK
+ekincare,careers@ekincare.com,Careers Desk,—,Hyderabad; corporate health-benefits SaaS; site-verified careers@; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2622,3 +2622,5 @@ Devathon,hello@devathon.com,Contact Desk,—,Hyderabad; product design & softwar
 Rapid Circuitry,contact@rapidcircuitry.com,Contact Desk,—,Hyderabad; PCB/embedded/IoT product dev; site-verified; MX OK
 MosChip Technologies,contact@moschip.com,Contact Desk,—,Hyderabad; semiconductor/VLSI/embedded design; site-verified; MX OK
 VALSOC Semiconductor,hr@valsocsemi.com,HR Desk,—,Hyderabad; VLSI/semiconductor design services; site-verified hr@; MX OK
+Innoit Labs,info@innoitlabs.com,Corporate Office,—,Hyderabad; web/mobile/cloud dev; site-verified; MX OK
+Analogue IT Solutions,info@analogueitsolutions.com,Corporate Office,—,Hyderabad; web/app/software dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2667,3 +2667,4 @@ Amigo Creatz,connect@amigocreatz.in,Contact Desk,—,Hyderabad; web/app dev & di
 Seven Web Tech,info@sevenwebtech.com,Corporate Office,—,Hyderabad; web/app/ecommerce dev; site-verified; MX OK
 HSB Infotech,info@hsbinfotech.com,Corporate Office,—,Hyderabad; custom software/web/mobile dev; site-verified; MX OK
 Tech Tree,info@techtree.in,Corporate Office,—,Hyderabad; custom software/web/mobile dev; site-verified; MX OK
+Pengwin Solutions,hyderabad@pengwinsolutions.com,Hyderabad Branch,—,Hyderabad (Gachibowli); web/mobile & custom software dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2584,3 +2584,9 @@ Webyansh,divyansh@webyansh.com,Contact Desk,General,Bengaluru Web Dev Agency; ve
 Hidden Brains,biz@hiddenbrains.com,Business Desk,General,Ahmedabad Web/App Dev Agency; verified on hiddenbrains.com site; MX OK
 eLuminous Technologies,hr@eluminoustechnologies.com,HR Desk,Recruitment,Pune Web/App Dev; verified on eluminoustechnologies.com site; MX OK; careers/HR inbox
 BrowserStack,careers@browserstack.com,Careers Desk,Recruitment,Mumbai Product (remote-first); verified on browserstack.com site; MX OK; careers/HR inbox
+MouriTech,info@mouritech.com,Corporate Office,—,Hyderabad; IT services/SAP/cloud; site-verified; MX OK
+Innominds,marketing@innominds.com,Marketing Desk,—,Hyderabad; product engineering/AI; site-verified; MX OK
+Divami Design Labs,info@divami.com,Corporate Office,—,Hyderabad; UX/product design+dev; site-verified; MX OK
+mroads,reachout@mroads.com,Contact Desk,—,Hyderabad; recruiting-tech+software; site-verified; MX OK
+Tvarana,info@tvarana.com,Corporate Office,—,Hyderabad; software/ServiceNow dev; site-verified; MX OK
+Nvish Solutions,sales@nvish.com,Sales Team,—,Hyderabad; IT services/analytics; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2671,3 +2671,4 @@ Pengwin Solutions,hyderabad@pengwinsolutions.com,Hyderabad Branch,—,Hyderabad 
 500apps,support@500apps.com,Contact Desk,—,Hyderabad; all-in-one business SaaS suite; site-verified; MX OK
 Geekschip,info@geekschip.com,Corporate Office,—,Hyderabad; digital marketing & web/app dev; site-verified; MX OK
 Pride Web Technologies,support@pridewebtech.com,Contact Desk,—,Hyderabad; web/app dev & digital marketing; site-verified; MX OK
+The Go-To Guy,enquiry@thegotoguy.co,Contact Desk,—,Hyderabad; web/app dev & digital marketing; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2688,3 +2688,4 @@ ekincare,careers@ekincare.com,Careers Desk,—,Hyderabad; corporate health-benef
 APPIT Software Solutions,info@appitsoftware.com,Corporate Office,—,Hyderabad; fleet/logistics ERP & custom software; site-verified; MX OK
 CloudAce Technologies,info@cloudacetechnologies.com,Corporate Office,—,Hyderabad; Google Cloud partner & cloud dev; site-verified; MX OK
 Apxor,contact@apxor.com,Contact Desk,—,Hyderabad; mobile product-analytics SaaS; site-verified; MX OK
+Modak Analytics,sales@modak.com,Sales Team,—,Hyderabad; data engineering/management platform; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2674,3 +2674,4 @@ Pride Web Technologies,support@pridewebtech.com,Contact Desk,—,Hyderabad; web/
 The Go-To Guy,enquiry@thegotoguy.co,Contact Desk,—,Hyderabad; web/app dev & digital marketing; site-verified; MX OK
 Phoxsite,hello@phoxsite.com,Contact Desk,—,Hyderabad; web design/development; site-verified; MX OK
 GBB (Global Bees Bots),hello@gbb.co.in,Contact Desk,—,Hyderabad; AWS/cloud consulting & migration; site-verified; MX OK
+BeyondScale Technologies,hello@beyondscale.tech,Contact Desk,—,"Hyderabad; AWS partner, cloud/DevOps & AI engineering; site-verified; MX OK"

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2597,3 +2597,4 @@ Riktam Technologies,ct@riktamtech.com,Contact Desk,—,Hyderabad; software/mobil
 InfoVision,info@infovision.com,Corporate Office,—,Hyderabad+Dallas; digital/cloud IT services; site-verified; MX OK
 Tech Vedika,info@techvedika.com,Corporate Office,—,Hyderabad HQ; AI/cloud/product engineering; site-verified; MX OK
 Miracle Software Systems,info@miraclesoft.com,Corporate Office,—,Hyderabad delivery center (Novi HQ); integration/cloud; site-verified; MX OK
+Aptagrim,info@aptagrim.com,Corporate Office,—,Hyderabad; data analytics/SAP/cloud; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2690,3 +2690,4 @@ CloudAce Technologies,info@cloudacetechnologies.com,Corporate Office,—,Hyderab
 Apxor,contact@apxor.com,Contact Desk,—,Hyderabad; mobile product-analytics SaaS; site-verified; MX OK
 Modak Analytics,sales@modak.com,Sales Team,—,Hyderabad; data engineering/management platform; site-verified; MX OK
 Algoleap Technologies,contact@algoleap.com,Contact Desk,—,Hyderabad; digital/data/AI engineering; site-verified; MX OK
+Keansa Solutions,info@keansa.com,Corporate Office,—,Hyderabad; data quality/analytics & IT services; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2642,3 +2642,4 @@ DigitalOps,hello@digitalops.in,Corporate Office,—,Hyderabad; web/app dev & dig
 Quixy (VividMinds Technologies),careers@quixy.com,Careers Desk,—,Hyderabad; no-code/low-code SaaS platform; site-verified careers@; MX OK
 Landeed (John Salt Pvt Ltd),customers@landeed.com,Contact Desk,—,Hyderabad; property-records/title-search SaaS; site-verified; MX OK
 Agasthya App Labs,info@agasthyaapplabs.com,Corporate Office,—,Hyderabad; mobile/web app development; site-verified; MX OK
+myMoneyKarma,askus@mymoneykarma.com,Contact Desk,—,Hyderabad; personal-finance/credit fintech; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2647,3 +2647,4 @@ CitiusTech,info@citiustech.com,Corporate Office,—,Hyderabad center; healthcare
 ValueMomentum,ContactNJ@valuemomentum.com,Contact Desk,—,Hyderabad center (Gachibowli); insurance/BFSI software; site-verified (US desk alias); MX OK
 Cambridge Technology Enterprises,sales@ctepl.com,Sales Team,—,Hyderabad HQ; AI/cloud/digital transformation; site-verified; MX OK
 WebNapp Studio,sales@webnappstudio.in,Sales Team,—,Hyderabad; Shopify/web & app dev; site-verified; MX OK
+Jeevan Scientific Technology,info@jeevanscientific.com,Corporate Office,—,Hyderabad; clinical research/pharmacovigilance IT; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2659,3 +2659,4 @@ Charter Global,sales@charterglobal.com,Sales Team,—,Hyderabad delivery center 
 AiFA Labs,info@aifalabs.com,Corporate Office,—,Hyderabad; enterprise AI/GenAI & IT services; site-verified; MX OK
 FindErnest,info@findernest.com,Corporate Office,—,Hyderabad; data/AI/cloud engineering & talent; site-verified; MX OK
 Lahari Technologies,support@laharitechnologies.com,Contact Desk,—,Hyderabad; web/mobile dev & IT services; site-verified; MX OK
+Premier Info City,hr@premierinfocity.com,HR Desk,—,Hyderabad; mobile app dev & IT staffing; site-verified hr@; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2676,3 +2676,4 @@ Phoxsite,hello@phoxsite.com,Contact Desk,—,Hyderabad; web design/development; 
 GBB (Global Bees Bots),hello@gbb.co.in,Contact Desk,—,Hyderabad; AWS/cloud consulting & migration; site-verified; MX OK
 BeyondScale Technologies,hello@beyondscale.tech,Contact Desk,—,"Hyderabad; AWS partner, cloud/DevOps & AI engineering; site-verified; MX OK"
 DataTerminal,contact@dataterminal.co,Contact Desk,—,Hyderabad; AI/data-engineering services & products; site-verified; MX OK
+BizAcuity Solutions,solutions@bizacuity.com,Contact Desk,—,Hyderabad; BI/data analytics & AI consulting; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2625,3 +2625,4 @@ VALSOC Semiconductor,hr@valsocsemi.com,HR Desk,—,Hyderabad; VLSI/semiconductor
 Innoit Labs,info@innoitlabs.com,Corporate Office,—,Hyderabad; web/mobile/cloud dev; site-verified; MX OK
 Analogue IT Solutions,info@analogueitsolutions.com,Corporate Office,—,Hyderabad; web/app/software dev; site-verified; MX OK
 Conquerors Tech,hr@conquerorstech.net,HR Desk,—,Hyderabad; custom software/web/mobile dev; site-verified hr@; MX OK
+iMatrix Solutions,info@imatrixsolutions.com,Corporate Office,—,Hyderabad; web design/dev & SEO; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2604,3 +2604,5 @@ Honey Soft Solutions,info@honeysoftsolutions.in,Corporate Office,—,Hyderabad; 
 Autorox,stayhappy@autorox.co,Contact Desk,—,Hyderabad; AI auto-workshop management SaaS; site-verified; MX OK
 Ahex Technologies,hr@ahex.co.in,HR Desk,—,Hyderabad; web/mobile/AI dev; site-verified hr@; MX OK
 SmartX Solutions,business@smartxsolutions.in,Contact Desk,—,Hyderabad; web/app/SaaS agency; site-verified; MX OK
+EasyQuickWeb,info@easyquickweb.com,Corporate Office,—,Hyderabad; web/digital agency; site-verified; MX OK
+Appdid Infotech,info@appdid.com,Corporate Office,—,Thane; mobile app/web dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2601,3 +2601,4 @@ Aptagrim,info@aptagrim.com,Corporate Office,—,Hyderabad; data analytics/SAP/cl
 NicheBit Softech,info@nichebit.com,Corporate Office,—,Hyderabad; software/web/mobile dev; site-verified; MX OK
 Pyramid SoftSol,careers@pyramidinc.com,Careers Desk,—,Hyderabad; enterprise software/QA/cloud; site-verified careers@; MX OK
 Honey Soft Solutions,info@honeysoftsolutions.in,Corporate Office,—,Hyderabad; web/software dev; site-verified; MX OK
+Autorox,stayhappy@autorox.co,Contact Desk,—,Hyderabad; AI auto-workshop management SaaS; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2591,3 +2591,6 @@ mroads,reachout@mroads.com,Contact Desk,—,Hyderabad; recruiting-tech+software;
 Tvarana,info@tvarana.com,Corporate Office,—,Hyderabad; software/ServiceNow dev; site-verified; MX OK
 Nvish Solutions,sales@nvish.com,Sales Team,—,Hyderabad; IT services/analytics; site-verified; MX OK
 CtrlS Datacenters,marketing@ctrls.in,Marketing Desk,—,Hyderabad; data centers/managed cloud; site-verified; MX OK
+Prowess Software Services,connect@prowesssoft.com,Contact Desk,—,Hyderabad; software product engineering/QA; site-verified; MX OK
+Bourntec Solutions,info@bourntec.com,HR / Recruitment Desk,—,Hyderabad+Chicago; cloud/data/digital; site-verified; MX OK
+Riktam Technologies,ct@riktamtech.com,Contact Desk,—,Hyderabad; software/mobile dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2652,3 +2652,4 @@ Marut Drones,enquiries@marutdrones.com,Contact Desk,—,Hyderabad; drone-tech + 
 Grene Robotics,workwithus@grenerobotics.com,Careers Desk,—,Hyderabad; autonomous systems/AI drone-defense; site-verified careers alias; MX OK
 IIC Technologies,info@iictechnologies.com,Corporate Office,—,Hyderabad HQ; geospatial/GIS software services; site-verified; MX OK
 Knack Systems,careers@knacksystems.com,Careers Desk,—,Hyderabad; SAP CX/enterprise consulting; site-verified careers@; MX OK
+Versatile Mobitech,hr@versatilemobitech.com,HR Desk,—,Hyderabad; web/mobile & ecommerce dev; site-verified hr@; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2678,3 +2678,4 @@ BeyondScale Technologies,hello@beyondscale.tech,Contact Desk,—,"Hyderabad; AWS
 DataTerminal,contact@dataterminal.co,Contact Desk,—,Hyderabad; AI/data-engineering services & products; site-verified; MX OK
 BizAcuity Solutions,solutions@bizacuity.com,Contact Desk,—,Hyderabad; BI/data analytics & AI consulting; site-verified; MX OK
 Helical IT Solutions,nikhilesh@helicaltech.com,Named Contact,—,Hyderabad; open-source BI/data warehousing; site-verified; MX OK
+Threshold Software Solutions,info@thresholdsoft.com,Corporate Office,—,Hyderabad; software dev & IT services; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2644,3 +2644,4 @@ Landeed (John Salt Pvt Ltd),customers@landeed.com,Contact Desk,—,Hyderabad; pr
 Agasthya App Labs,info@agasthyaapplabs.com,Corporate Office,—,Hyderabad; mobile/web app development; site-verified; MX OK
 myMoneyKarma,askus@mymoneykarma.com,Contact Desk,—,Hyderabad; personal-finance/credit fintech; site-verified; MX OK
 CitiusTech,info@citiustech.com,Corporate Office,—,Hyderabad center; healthcare IT/consulting; site-verified; MX OK
+ValueMomentum,ContactNJ@valuemomentum.com,Contact Desk,—,Hyderabad center (Gachibowli); insurance/BFSI software; site-verified (US desk alias); MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2660,3 +2660,4 @@ AiFA Labs,info@aifalabs.com,Corporate Office,—,Hyderabad; enterprise AI/GenAI 
 FindErnest,info@findernest.com,Corporate Office,—,Hyderabad; data/AI/cloud engineering & talent; site-verified; MX OK
 Lahari Technologies,support@laharitechnologies.com,Contact Desk,—,Hyderabad; web/mobile dev & IT services; site-verified; MX OK
 Premier Info City,hr@premierinfocity.com,HR Desk,—,Hyderabad; mobile app dev & IT staffing; site-verified hr@; MX OK
+Conrep Solutions,sales@conrep.com,Sales Team,—,Hyderabad (Jubilee Hills)+US; PSA/staffing software product; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2675,3 +2675,4 @@ The Go-To Guy,enquiry@thegotoguy.co,Contact Desk,—,Hyderabad; web/app dev & di
 Phoxsite,hello@phoxsite.com,Contact Desk,—,Hyderabad; web design/development; site-verified; MX OK
 GBB (Global Bees Bots),hello@gbb.co.in,Contact Desk,—,Hyderabad; AWS/cloud consulting & migration; site-verified; MX OK
 BeyondScale Technologies,hello@beyondscale.tech,Contact Desk,—,"Hyderabad; AWS partner, cloud/DevOps & AI engineering; site-verified; MX OK"
+DataTerminal,contact@dataterminal.co,Contact Desk,—,Hyderabad; AI/data-engineering services & products; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2702,3 +2702,4 @@ Adepto Geoinformatics,info@adeptogeoit.com,Corporate Office,—,Hyderabad; GIS/g
 ASTROC AS Technology,info@astrocastech.in,Corporate Office,—,Hyderabad; autonomous drones/UGVs & AI deep-tech; site-verified; MX OK
 NaPanta,support@napanta.com,Contact Desk,—,Hyderabad; agri-advisory/farm management SaaS; site-verified; MX OK
 Thanos Technologies,contact@thanos.in,Contact Desk,—,Hyderabad; agri-drone & precision-ag tech; site-verified; MX OK
+Tutorials Point,media@tutorialspoint.com,Contact Desk,—,Hyderabad; ed-content/e-learning platform; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2693,3 +2693,4 @@ Algoleap Technologies,contact@algoleap.com,Contact Desk,—,Hyderabad; digital/d
 Keansa Solutions,info@keansa.com,Corporate Office,—,Hyderabad; data quality/analytics & IT services; site-verified; MX OK
 Haystek Technologies,hr@haystek.com,HR Desk,—,Hyderabad; web/mobile app & software dev; site-verified hr@; MX OK
 Vaakruthi Software Solutions,info@vaakruthi.co.in,Corporate Office,—,Hyderabad; web/mobile/software dev & staffing; site-verified; MX OK
+CentoTech Services,info@centotech.com,Corporate Office,—,Hyderabad; web/mobile app & software dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2636,3 +2636,5 @@ Waytowebs,info@waytowebs.com,Corporate Office,—,Hyderabad; web/app/UI-UX desig
 CreditMitra,support@creditmitra.in,Contact Desk,—,Hyderabad; lending/insurance fintech; site-verified; MX OK
 Digital Eyecon,info@digitaleyecon.com,Corporate Office,—,Hyderabad; web/mobile dev & digital marketing; site-verified; MX OK
 ThreeAtoms,contact@threeatoms.com,Contact Desk,—,Hyderabad; web/app software dev; site-verified; MX OK
+Toyaja,sales@toyaja.com,Sales Team,—,Hyderabad; web/mobile/enterprise dev; site-verified; MX OK
+SlashMonk,info@slashmonk.com,Corporate Office,—,Hyderabad; product/web engineering; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2692,3 +2692,4 @@ Modak Analytics,sales@modak.com,Sales Team,—,Hyderabad; data engineering/manag
 Algoleap Technologies,contact@algoleap.com,Contact Desk,—,Hyderabad; digital/data/AI engineering; site-verified; MX OK
 Keansa Solutions,info@keansa.com,Corporate Office,—,Hyderabad; data quality/analytics & IT services; site-verified; MX OK
 Haystek Technologies,hr@haystek.com,HR Desk,—,Hyderabad; web/mobile app & software dev; site-verified hr@; MX OK
+Vaakruthi Software Solutions,info@vaakruthi.co.in,Corporate Office,—,Hyderabad; web/mobile/software dev & staffing; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2656,3 +2656,4 @@ Versatile Mobitech,hr@versatilemobitech.com,HR Desk,—,Hyderabad; web/mobile & 
 KBK Business Solutions,info@kbkbusinesssolutions.com,Corporate Office,—,Hyderabad; web dev & digital marketing; site-verified; MX OK
 Origin Softwares,info@originsoftwares.com,Corporate Office,—,Hyderabad; custom software/web/mobile dev; site-verified; MX OK
 Charter Global,sales@charterglobal.com,Sales Team,—,Hyderabad delivery center (US HQ); IT services/data/AI; site-verified; MX OK
+AiFA Labs,info@aifalabs.com,Corporate Office,—,Hyderabad; enterprise AI/GenAI & IT services; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2657,3 +2657,4 @@ KBK Business Solutions,info@kbkbusinesssolutions.com,Corporate Office,—,Hydera
 Origin Softwares,info@originsoftwares.com,Corporate Office,—,Hyderabad; custom software/web/mobile dev; site-verified; MX OK
 Charter Global,sales@charterglobal.com,Sales Team,—,Hyderabad delivery center (US HQ); IT services/data/AI; site-verified; MX OK
 AiFA Labs,info@aifalabs.com,Corporate Office,—,Hyderabad; enterprise AI/GenAI & IT services; site-verified; MX OK
+FindErnest,info@findernest.com,Corporate Office,—,Hyderabad; data/AI/cloud engineering & talent; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2650,3 +2650,4 @@ WebNapp Studio,sales@webnappstudio.in,Sales Team,—,Hyderabad; Shopify/web & ap
 Jeevan Scientific Technology,info@jeevanscientific.com,Corporate Office,—,Hyderabad; clinical research/pharmacovigilance IT; site-verified; MX OK
 Marut Drones,enquiries@marutdrones.com,Contact Desk,—,Hyderabad; drone-tech + software/AI; site-verified; MX OK
 Grene Robotics,workwithus@grenerobotics.com,Careers Desk,—,Hyderabad; autonomous systems/AI drone-defense; site-verified careers alias; MX OK
+IIC Technologies,info@iictechnologies.com,Corporate Office,—,Hyderabad HQ; geospatial/GIS software services; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2614,3 +2614,5 @@ SYOFT,info@syoft.com,Corporate Office,—,Hyderabad; mobile app/web/low-code dev
 USM Business Systems,sales@usmsystems.com,Sales Team,—,Hyderabad delivery center (US HQ); IT staffing/software/AI; site-verified; MX OK
 Ogre Head Studio,support@ogrehead.com,Contact Desk,—,Hyderabad; indie game studio; site-verified; MX OK
 GameNexa Studios,info@gamenexa.com,Corporate Office,—,Hyderabad; mobile app/game dev; site-verified; MX OK
+AppShark Software,sales@appshark.com,Sales Team,—,Hyderabad; Salesforce/enterprise app dev; site-verified; MX OK
+Vikisol Technologies,connect@vikisol.in,Contact Desk,—,Hyderabad; Salesforce/SAP/ServiceNow consulting; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2664,3 +2664,4 @@ Conrep Solutions,sales@conrep.com,Sales Team,—,Hyderabad (Jubilee Hills)+US; P
 Web Synergies,sales@websynergies.com,Sales Team,—,Hyderabad (Banjara Hills); digital transformation/web/cloud; site-verified; MX OK
 Stratosphere IT Services,info@stratosphere.co.in,Corporate Office,—,Hyderabad; software dev & IT services; site-verified; MX OK
 Amigo Creatz,connect@amigocreatz.in,Contact Desk,—,Hyderabad; web/app dev & digital marketing; site-verified; MX OK
+Seven Web Tech,info@sevenwebtech.com,Corporate Office,—,Hyderabad; web/app/ecommerce dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2646,3 +2646,4 @@ myMoneyKarma,askus@mymoneykarma.com,Contact Desk,—,Hyderabad; personal-finance
 CitiusTech,info@citiustech.com,Corporate Office,—,Hyderabad center; healthcare IT/consulting; site-verified; MX OK
 ValueMomentum,ContactNJ@valuemomentum.com,Contact Desk,—,Hyderabad center (Gachibowli); insurance/BFSI software; site-verified (US desk alias); MX OK
 Cambridge Technology Enterprises,sales@ctepl.com,Sales Team,—,Hyderabad HQ; AI/cloud/digital transformation; site-verified; MX OK
+WebNapp Studio,sales@webnappstudio.in,Sales Team,—,Hyderabad; Shopify/web & app dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2639,3 +2639,4 @@ ThreeAtoms,contact@threeatoms.com,Contact Desk,—,Hyderabad; web/app software d
 Toyaja,sales@toyaja.com,Sales Team,—,Hyderabad; web/mobile/enterprise dev; site-verified; MX OK
 SlashMonk,info@slashmonk.com,Corporate Office,—,Hyderabad; product/web engineering; site-verified; MX OK
 DigitalOps,hello@digitalops.in,Corporate Office,—,Hyderabad; web/app dev & digital solutions; site-verified; MX OK
+Quixy (VividMinds Technologies),careers@quixy.com,Careers Desk,—,Hyderabad; no-code/low-code SaaS platform; site-verified careers@; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2681,3 +2681,4 @@ Helical IT Solutions,nikhilesh@helicaltech.com,Named Contact,—,Hyderabad; open
 Threshold Software Solutions,info@thresholdsoft.com,Corporate Office,—,Hyderabad; software dev & IT services; site-verified; MX OK
 Runo,care@runo.ai,Contact Desk,—,Hyderabad; call-management/CRM SaaS; site-verified; MX OK
 FreJun,hello@frejun.com,Contact Desk,—,Hyderabad; virtual-calling/telephony SaaS; site-verified; MX OK
+Kenyt.AI,careers@kenyt.ai,Careers Desk,—,Hyderabad; conversational-AI chatbot SaaS; site-verified careers@; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2609,3 +2609,5 @@ Appdid Infotech,info@appdid.com,Corporate Office,—,Thane; mobile app/web dev; 
 OzrIT,hr@ozrit.com,HR Desk,—,Hyderabad; web/mobile/cloud dev; site-verified hr@; MX OK
 Techweblabs,info@techweblabs.com,Corporate Office,—,Hyderabad; web/app/AI dev (T-Hub); site-verified; MX OK
 Codetru,queries@codetru.com,Contact Desk,—,Hyderabad; software/web/mobile & AI dev; site-verified; MX OK
+Tech Cloud ERP,sales@techclouderp.com,Sales Team,—,Hyderabad; cloud ERP product; site-verified; MX OK
+SYOFT,info@syoft.com,Corporate Office,—,Hyderabad; mobile app/web/low-code dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2616,3 +2616,4 @@ Ogre Head Studio,support@ogrehead.com,Contact Desk,—,Hyderabad; indie game stu
 GameNexa Studios,info@gamenexa.com,Corporate Office,—,Hyderabad; mobile app/game dev; site-verified; MX OK
 AppShark Software,sales@appshark.com,Sales Team,—,Hyderabad; Salesforce/enterprise app dev; site-verified; MX OK
 Vikisol Technologies,connect@vikisol.in,Contact Desk,—,Hyderabad; Salesforce/SAP/ServiceNow consulting; site-verified; MX OK
+MicroPyramid,hello@micropyramid.com,Contact Desk,—,Hyderabad; Python/Django/Salesforce & cloud dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2645,3 +2645,4 @@ Agasthya App Labs,info@agasthyaapplabs.com,Corporate Office,—,Hyderabad; mobil
 myMoneyKarma,askus@mymoneykarma.com,Contact Desk,—,Hyderabad; personal-finance/credit fintech; site-verified; MX OK
 CitiusTech,info@citiustech.com,Corporate Office,—,Hyderabad center; healthcare IT/consulting; site-verified; MX OK
 ValueMomentum,ContactNJ@valuemomentum.com,Contact Desk,—,Hyderabad center (Gachibowli); insurance/BFSI software; site-verified (US desk alias); MX OK
+Cambridge Technology Enterprises,sales@ctepl.com,Sales Team,—,Hyderabad HQ; AI/cloud/digital transformation; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2617,3 +2617,5 @@ GameNexa Studios,info@gamenexa.com,Corporate Office,—,Hyderabad; mobile app/ga
 AppShark Software,sales@appshark.com,Sales Team,—,Hyderabad; Salesforce/enterprise app dev; site-verified; MX OK
 Vikisol Technologies,connect@vikisol.in,Contact Desk,—,Hyderabad; Salesforce/SAP/ServiceNow consulting; site-verified; MX OK
 MicroPyramid,hello@micropyramid.com,Contact Desk,—,Hyderabad; Python/Django/Salesforce & cloud dev; site-verified; MX OK
+Veritis Group,connect@veritis.com,Contact Desk,—,Hyderabad; DevOps/cloud/IT consulting; site-verified; MX OK
+Devathon,hello@devathon.com,Contact Desk,—,Hyderabad; product design & software dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2640,3 +2640,4 @@ Toyaja,sales@toyaja.com,Sales Team,—,Hyderabad; web/mobile/enterprise dev; sit
 SlashMonk,info@slashmonk.com,Corporate Office,—,Hyderabad; product/web engineering; site-verified; MX OK
 DigitalOps,hello@digitalops.in,Corporate Office,—,Hyderabad; web/app dev & digital solutions; site-verified; MX OK
 Quixy (VividMinds Technologies),careers@quixy.com,Careers Desk,—,Hyderabad; no-code/low-code SaaS platform; site-verified careers@; MX OK
+Landeed (John Salt Pvt Ltd),customers@landeed.com,Contact Desk,—,Hyderabad; property-records/title-search SaaS; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2704,3 +2704,4 @@ NaPanta,support@napanta.com,Contact Desk,—,Hyderabad; agri-advisory/farm manag
 Thanos Technologies,contact@thanos.in,Contact Desk,—,Hyderabad; agri-drone & precision-ag tech; site-verified; MX OK
 Tutorials Point,media@tutorialspoint.com,Contact Desk,—,Hyderabad; ed-content/e-learning platform; site-verified; MX OK
 360DigiTMG,info@360digitmg.com,Corporate Office,—,Hyderabad; data-science/AI training & analytics; site-verified; MX OK
+IncNut Digital,support@incnut.com,Contact Desk,—,Hyderabad; digital media/D2C tech; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2590,3 +2590,4 @@ Divami Design Labs,info@divami.com,Corporate Office,—,Hyderabad; UX/product de
 mroads,reachout@mroads.com,Contact Desk,—,Hyderabad; recruiting-tech+software; site-verified; MX OK
 Tvarana,info@tvarana.com,Corporate Office,—,Hyderabad; software/ServiceNow dev; site-verified; MX OK
 Nvish Solutions,sales@nvish.com,Sales Team,—,Hyderabad; IT services/analytics; site-verified; MX OK
+CtrlS Datacenters,marketing@ctrls.in,Marketing Desk,—,Hyderabad; data centers/managed cloud; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2633,3 +2633,4 @@ DataSpeaks,hello@dataspeaks.co,Contact Desk,—,Hyderabad; data engineering/anal
 Gleecus TechLabs,hello@gleecus.com,Contact Desk,—,"Hyderabad; digital/product engineering, AI & cloud; site-verified; MX OK"
 Tek Leaders,info@tekleaders.com,Corporate Office,—,Hyderabad; IT services/data & cloud; site-verified; MX OK
 Waytowebs,info@waytowebs.com,Corporate Office,—,Hyderabad; web/app/UI-UX design & dev; site-verified; MX OK
+CreditMitra,support@creditmitra.in,Contact Desk,—,Hyderabad; lending/insurance fintech; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2648,3 +2648,4 @@ ValueMomentum,ContactNJ@valuemomentum.com,Contact Desk,—,Hyderabad center (Gac
 Cambridge Technology Enterprises,sales@ctepl.com,Sales Team,—,Hyderabad HQ; AI/cloud/digital transformation; site-verified; MX OK
 WebNapp Studio,sales@webnappstudio.in,Sales Team,—,Hyderabad; Shopify/web & app dev; site-verified; MX OK
 Jeevan Scientific Technology,info@jeevanscientific.com,Corporate Office,—,Hyderabad; clinical research/pharmacovigilance IT; site-verified; MX OK
+Marut Drones,enquiries@marutdrones.com,Contact Desk,—,Hyderabad; drone-tech + software/AI; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2602,3 +2602,5 @@ NicheBit Softech,info@nichebit.com,Corporate Office,—,Hyderabad; software/web/
 Pyramid SoftSol,careers@pyramidinc.com,Careers Desk,—,Hyderabad; enterprise software/QA/cloud; site-verified careers@; MX OK
 Honey Soft Solutions,info@honeysoftsolutions.in,Corporate Office,—,Hyderabad; web/software dev; site-verified; MX OK
 Autorox,stayhappy@autorox.co,Contact Desk,—,Hyderabad; AI auto-workshop management SaaS; site-verified; MX OK
+Ahex Technologies,hr@ahex.co.in,HR Desk,—,Hyderabad; web/mobile/AI dev; site-verified hr@; MX OK
+SmartX Solutions,business@smartxsolutions.in,Contact Desk,—,Hyderabad; web/app/SaaS agency; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2698,3 +2698,4 @@ Innvectra,info@innvectra.com,Corporate Office,—,Hyderabad; web/mobile/software
 Team Erudite,accounts@teamerudite.com,Contact Desk,—,Hyderabad; web/mobile app & software dev; site-verified; MX OK
 Magnaquest Technologies,sales@magnaquest.com,Sales Team,—,Hyderabad; subscription/billing software product; site-verified; MX OK
 Helical IT Solutions,nitin@helicaltech.com,Nitin Sagar,Co-Founder / Director,Hyderabad; named contact site-verified; MX OK
+Adepto Geoinformatics,info@adeptogeoit.com,Corporate Office,—,Hyderabad; GIS/geospatial IT & image processing; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2682,3 +2682,4 @@ Threshold Software Solutions,info@thresholdsoft.com,Corporate Office,—,Hyderab
 Runo,care@runo.ai,Contact Desk,—,Hyderabad; call-management/CRM SaaS; site-verified; MX OK
 FreJun,hello@frejun.com,Contact Desk,—,Hyderabad; virtual-calling/telephony SaaS; site-verified; MX OK
 Kenyt.AI,careers@kenyt.ai,Careers Desk,—,Hyderabad; conversational-AI chatbot SaaS; site-verified careers@; MX OK
+SignalX.ai,sales@signalx.ai,Sales Team,—,Hyderabad; AI risk/due-diligence SaaS; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2694,3 +2694,4 @@ Keansa Solutions,info@keansa.com,Corporate Office,—,Hyderabad; data quality/an
 Haystek Technologies,hr@haystek.com,HR Desk,—,Hyderabad; web/mobile app & software dev; site-verified hr@; MX OK
 Vaakruthi Software Solutions,info@vaakruthi.co.in,Corporate Office,—,Hyderabad; web/mobile/software dev & staffing; site-verified; MX OK
 CentoTech Services,info@centotech.com,Corporate Office,—,Hyderabad; web/mobile app & software dev; site-verified; MX OK
+Innvectra,info@innvectra.com,Corporate Office,—,Hyderabad; web/mobile/software dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2672,3 +2672,4 @@ Pengwin Solutions,hyderabad@pengwinsolutions.com,Hyderabad Branch,—,Hyderabad 
 Geekschip,info@geekschip.com,Corporate Office,—,Hyderabad; digital marketing & web/app dev; site-verified; MX OK
 Pride Web Technologies,support@pridewebtech.com,Contact Desk,—,Hyderabad; web/app dev & digital marketing; site-verified; MX OK
 The Go-To Guy,enquiry@thegotoguy.co,Contact Desk,—,Hyderabad; web/app dev & digital marketing; site-verified; MX OK
+Phoxsite,hello@phoxsite.com,Contact Desk,—,Hyderabad; web design/development; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2599,3 +2599,5 @@ Tech Vedika,info@techvedika.com,Corporate Office,—,Hyderabad HQ; AI/cloud/prod
 Miracle Software Systems,info@miraclesoft.com,Corporate Office,—,Hyderabad delivery center (Novi HQ); integration/cloud; site-verified; MX OK
 Aptagrim,info@aptagrim.com,Corporate Office,—,Hyderabad; data analytics/SAP/cloud; site-verified; MX OK
 NicheBit Softech,info@nichebit.com,Corporate Office,—,Hyderabad; software/web/mobile dev; site-verified; MX OK
+Pyramid SoftSol,careers@pyramidinc.com,Careers Desk,—,Hyderabad; enterprise software/QA/cloud; site-verified careers@; MX OK
+Honey Soft Solutions,info@honeysoftsolutions.in,Corporate Office,—,Hyderabad; web/software dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2641,3 +2641,4 @@ SlashMonk,info@slashmonk.com,Corporate Office,—,Hyderabad; product/web enginee
 DigitalOps,hello@digitalops.in,Corporate Office,—,Hyderabad; web/app dev & digital solutions; site-verified; MX OK
 Quixy (VividMinds Technologies),careers@quixy.com,Careers Desk,—,Hyderabad; no-code/low-code SaaS platform; site-verified careers@; MX OK
 Landeed (John Salt Pvt Ltd),customers@landeed.com,Contact Desk,—,Hyderabad; property-records/title-search SaaS; site-verified; MX OK
+Agasthya App Labs,info@agasthyaapplabs.com,Corporate Office,—,Hyderabad; mobile/web app development; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2655,3 +2655,4 @@ Knack Systems,careers@knacksystems.com,Careers Desk,—,Hyderabad; SAP CX/enterp
 Versatile Mobitech,hr@versatilemobitech.com,HR Desk,—,Hyderabad; web/mobile & ecommerce dev; site-verified hr@; MX OK
 KBK Business Solutions,info@kbkbusinesssolutions.com,Corporate Office,—,Hyderabad; web dev & digital marketing; site-verified; MX OK
 Origin Softwares,info@originsoftwares.com,Corporate Office,—,Hyderabad; custom software/web/mobile dev; site-verified; MX OK
+Charter Global,sales@charterglobal.com,Sales Team,—,Hyderabad delivery center (US HQ); IT services/data/AI; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2612,3 +2612,5 @@ Codetru,queries@codetru.com,Contact Desk,—,Hyderabad; software/web/mobile & AI
 Tech Cloud ERP,sales@techclouderp.com,Sales Team,—,Hyderabad; cloud ERP product; site-verified; MX OK
 SYOFT,info@syoft.com,Corporate Office,—,Hyderabad; mobile app/web/low-code dev; site-verified; MX OK
 USM Business Systems,sales@usmsystems.com,Sales Team,—,Hyderabad delivery center (US HQ); IT staffing/software/AI; site-verified; MX OK
+Ogre Head Studio,support@ogrehead.com,Contact Desk,—,Hyderabad; indie game studio; site-verified; MX OK
+GameNexa Studios,info@gamenexa.com,Corporate Office,—,Hyderabad; mobile app/game dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2638,3 +2638,4 @@ Digital Eyecon,info@digitaleyecon.com,Corporate Office,—,Hyderabad; web/mobile
 ThreeAtoms,contact@threeatoms.com,Contact Desk,—,Hyderabad; web/app software dev; site-verified; MX OK
 Toyaja,sales@toyaja.com,Sales Team,—,Hyderabad; web/mobile/enterprise dev; site-verified; MX OK
 SlashMonk,info@slashmonk.com,Corporate Office,—,Hyderabad; product/web engineering; site-verified; MX OK
+DigitalOps,hello@digitalops.in,Corporate Office,—,Hyderabad; web/app dev & digital solutions; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2662,3 +2662,4 @@ Lahari Technologies,support@laharitechnologies.com,Contact Desk,—,Hyderabad; w
 Premier Info City,hr@premierinfocity.com,HR Desk,—,Hyderabad; mobile app dev & IT staffing; site-verified hr@; MX OK
 Conrep Solutions,sales@conrep.com,Sales Team,—,Hyderabad (Jubilee Hills)+US; PSA/staffing software product; site-verified; MX OK
 Web Synergies,sales@websynergies.com,Sales Team,—,Hyderabad (Banjara Hills); digital transformation/web/cloud; site-verified; MX OK
+Stratosphere IT Services,info@stratosphere.co.in,Corporate Office,—,Hyderabad; software dev & IT services; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2687,3 +2687,4 @@ Param.ai,sales@param.ai,Sales Team,—,Hyderabad; AI recruitment/talent SaaS; si
 ekincare,careers@ekincare.com,Careers Desk,—,Hyderabad; corporate health-benefits SaaS; site-verified careers@; MX OK
 APPIT Software Solutions,info@appitsoftware.com,Corporate Office,—,Hyderabad; fleet/logistics ERP & custom software; site-verified; MX OK
 CloudAce Technologies,info@cloudacetechnologies.com,Corporate Office,—,Hyderabad; Google Cloud partner & cloud dev; site-verified; MX OK
+Apxor,contact@apxor.com,Contact Desk,—,Hyderabad; mobile product-analytics SaaS; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2701,3 +2701,4 @@ Helical IT Solutions,nitin@helicaltech.com,Nitin Sagar,Co-Founder / Director,Hyd
 Adepto Geoinformatics,info@adeptogeoit.com,Corporate Office,—,Hyderabad; GIS/geospatial IT & image processing; site-verified; MX OK
 ASTROC AS Technology,info@astrocastech.in,Corporate Office,—,Hyderabad; autonomous drones/UGVs & AI deep-tech; site-verified; MX OK
 NaPanta,support@napanta.com,Contact Desk,—,Hyderabad; agri-advisory/farm management SaaS; site-verified; MX OK
+Thanos Technologies,contact@thanos.in,Contact Desk,—,Hyderabad; agri-drone & precision-ag tech; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2624,3 +2624,4 @@ MosChip Technologies,contact@moschip.com,Contact Desk,—,Hyderabad; semiconduct
 VALSOC Semiconductor,hr@valsocsemi.com,HR Desk,—,Hyderabad; VLSI/semiconductor design services; site-verified hr@; MX OK
 Innoit Labs,info@innoitlabs.com,Corporate Office,—,Hyderabad; web/mobile/cloud dev; site-verified; MX OK
 Analogue IT Solutions,info@analogueitsolutions.com,Corporate Office,—,Hyderabad; web/app/software dev; site-verified; MX OK
+Conquerors Tech,hr@conquerorstech.net,HR Desk,—,Hyderabad; custom software/web/mobile dev; site-verified hr@; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2691,3 +2691,4 @@ Apxor,contact@apxor.com,Contact Desk,—,Hyderabad; mobile product-analytics Saa
 Modak Analytics,sales@modak.com,Sales Team,—,Hyderabad; data engineering/management platform; site-verified; MX OK
 Algoleap Technologies,contact@algoleap.com,Contact Desk,—,Hyderabad; digital/data/AI engineering; site-verified; MX OK
 Keansa Solutions,info@keansa.com,Corporate Office,—,Hyderabad; data quality/analytics & IT services; site-verified; MX OK
+Haystek Technologies,hr@haystek.com,HR Desk,—,Hyderabad; web/mobile app & software dev; site-verified hr@; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2686,3 +2686,4 @@ SignalX.ai,sales@signalx.ai,Sales Team,—,Hyderabad; AI risk/due-diligence SaaS
 Param.ai,sales@param.ai,Sales Team,—,Hyderabad; AI recruitment/talent SaaS; site-verified; MX OK
 ekincare,careers@ekincare.com,Careers Desk,—,Hyderabad; corporate health-benefits SaaS; site-verified careers@; MX OK
 APPIT Software Solutions,info@appitsoftware.com,Corporate Office,—,Hyderabad; fleet/logistics ERP & custom software; site-verified; MX OK
+CloudAce Technologies,info@cloudacetechnologies.com,Corporate Office,—,Hyderabad; Google Cloud partner & cloud dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2670,3 +2670,4 @@ Tech Tree,info@techtree.in,Corporate Office,—,Hyderabad; custom software/web/m
 Pengwin Solutions,hyderabad@pengwinsolutions.com,Hyderabad Branch,—,Hyderabad (Gachibowli); web/mobile & custom software dev; site-verified; MX OK
 500apps,support@500apps.com,Contact Desk,—,Hyderabad; all-in-one business SaaS suite; site-verified; MX OK
 Geekschip,info@geekschip.com,Corporate Office,—,Hyderabad; digital marketing & web/app dev; site-verified; MX OK
+Pride Web Technologies,support@pridewebtech.com,Contact Desk,—,Hyderabad; web/app dev & digital marketing; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2663,3 +2663,4 @@ Premier Info City,hr@premierinfocity.com,HR Desk,—,Hyderabad; mobile app dev &
 Conrep Solutions,sales@conrep.com,Sales Team,—,Hyderabad (Jubilee Hills)+US; PSA/staffing software product; site-verified; MX OK
 Web Synergies,sales@websynergies.com,Sales Team,—,Hyderabad (Banjara Hills); digital transformation/web/cloud; site-verified; MX OK
 Stratosphere IT Services,info@stratosphere.co.in,Corporate Office,—,Hyderabad; software dev & IT services; site-verified; MX OK
+Amigo Creatz,connect@amigocreatz.in,Contact Desk,—,Hyderabad; web/app dev & digital marketing; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2665,3 +2665,4 @@ Web Synergies,sales@websynergies.com,Sales Team,—,Hyderabad (Banjara Hills); d
 Stratosphere IT Services,info@stratosphere.co.in,Corporate Office,—,Hyderabad; software dev & IT services; site-verified; MX OK
 Amigo Creatz,connect@amigocreatz.in,Contact Desk,—,Hyderabad; web/app dev & digital marketing; site-verified; MX OK
 Seven Web Tech,info@sevenwebtech.com,Corporate Office,—,Hyderabad; web/app/ecommerce dev; site-verified; MX OK
+HSB Infotech,info@hsbinfotech.com,Corporate Office,—,Hyderabad; custom software/web/mobile dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2679,3 +2679,4 @@ DataTerminal,contact@dataterminal.co,Contact Desk,—,Hyderabad; AI/data-enginee
 BizAcuity Solutions,solutions@bizacuity.com,Contact Desk,—,Hyderabad; BI/data analytics & AI consulting; site-verified; MX OK
 Helical IT Solutions,nikhilesh@helicaltech.com,Named Contact,—,Hyderabad; open-source BI/data warehousing; site-verified; MX OK
 Threshold Software Solutions,info@thresholdsoft.com,Corporate Office,—,Hyderabad; software dev & IT services; site-verified; MX OK
+Runo,care@runo.ai,Contact Desk,—,Hyderabad; call-management/CRM SaaS; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2680,3 +2680,4 @@ BizAcuity Solutions,solutions@bizacuity.com,Contact Desk,—,Hyderabad; BI/data 
 Helical IT Solutions,nikhilesh@helicaltech.com,Named Contact,—,Hyderabad; open-source BI/data warehousing; site-verified; MX OK
 Threshold Software Solutions,info@thresholdsoft.com,Corporate Office,—,Hyderabad; software dev & IT services; site-verified; MX OK
 Runo,care@runo.ai,Contact Desk,—,Hyderabad; call-management/CRM SaaS; site-verified; MX OK
+FreJun,hello@frejun.com,Contact Desk,—,Hyderabad; virtual-calling/telephony SaaS; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2608,3 +2608,4 @@ EasyQuickWeb,info@easyquickweb.com,Corporate Office,—,Hyderabad; web/digital a
 Appdid Infotech,info@appdid.com,Corporate Office,—,Thane; mobile app/web dev; site-verified; MX OK
 OzrIT,hr@ozrit.com,HR Desk,—,Hyderabad; web/mobile/cloud dev; site-verified hr@; MX OK
 Techweblabs,info@techweblabs.com,Corporate Office,—,Hyderabad; web/app/AI dev (T-Hub); site-verified; MX OK
+Codetru,queries@codetru.com,Contact Desk,—,Hyderabad; software/web/mobile & AI dev; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2668,3 +2668,4 @@ Seven Web Tech,info@sevenwebtech.com,Corporate Office,—,Hyderabad; web/app/eco
 HSB Infotech,info@hsbinfotech.com,Corporate Office,—,Hyderabad; custom software/web/mobile dev; site-verified; MX OK
 Tech Tree,info@techtree.in,Corporate Office,—,Hyderabad; custom software/web/mobile dev; site-verified; MX OK
 Pengwin Solutions,hyderabad@pengwinsolutions.com,Hyderabad Branch,—,Hyderabad (Gachibowli); web/mobile & custom software dev; site-verified; MX OK
+500apps,support@500apps.com,Contact Desk,—,Hyderabad; all-in-one business SaaS suite; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2653,3 +2653,4 @@ Grene Robotics,workwithus@grenerobotics.com,Careers Desk,—,Hyderabad; autonomo
 IIC Technologies,info@iictechnologies.com,Corporate Office,—,Hyderabad HQ; geospatial/GIS software services; site-verified; MX OK
 Knack Systems,careers@knacksystems.com,Careers Desk,—,Hyderabad; SAP CX/enterprise consulting; site-verified careers@; MX OK
 Versatile Mobitech,hr@versatilemobitech.com,HR Desk,—,Hyderabad; web/mobile & ecommerce dev; site-verified hr@; MX OK
+KBK Business Solutions,info@kbkbusinesssolutions.com,Corporate Office,—,Hyderabad; web dev & digital marketing; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2695,3 +2695,4 @@ Haystek Technologies,hr@haystek.com,HR Desk,—,Hyderabad; web/mobile app & soft
 Vaakruthi Software Solutions,info@vaakruthi.co.in,Corporate Office,—,Hyderabad; web/mobile/software dev & staffing; site-verified; MX OK
 CentoTech Services,info@centotech.com,Corporate Office,—,Hyderabad; web/mobile app & software dev; site-verified; MX OK
 Innvectra,info@innvectra.com,Corporate Office,—,Hyderabad; web/mobile/software dev; site-verified; MX OK
+Team Erudite,accounts@teamerudite.com,Contact Desk,—,Hyderabad; web/mobile app & software dev; site-verified; MX OK

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -35,3 +35,11 @@
 ,Myntra,bheem.jantaka@myntra.com,Bheem Jantaka,General Manager,Hyderabad,Myntra leadership list; Hyderabad
 ,Lab for Spatial Informatics at International Institute of Information Technology Hyderabad (IIITH),kuldeep.kurte@iiit.ac.in,HR,HR,Hyderabad,DataNiti-HR-Profiles
 ,AIESEC Hyderabad,soum.chava@gmail.com,Soumya Chava,HR,Hyderabad,DataNiti-Verified-HR
+,MouriTech,info@mouritech.com,Corporate Office,General,Hyderabad,Hyderabad HQ; SAP/cloud/IT services; VERIFIED printed on mouritech.com/contact-us (mailto); MX OK (Mimecast)
+,Anblicks,careers@anblicks.com,Careers Desk,Recruitment,Hyderabad,Hyderabad+Dallas; data/AI/cloud modernization; VERIFIED printed on anblicks.com/contact-us; MX OK (Barracuda)
+,Anblicks,info@anblicks.com,Corporate Office,General,Hyderabad,Hyderabad+Dallas; data/AI/cloud; VERIFIED printed on anblicks.com/contact-us; MX OK (Barracuda)
+,Innominds,marketing@innominds.com,Marketing Desk,Marketing,Hyderabad,Hyderabad; product engineering/AI/IoT; VERIFIED printed on innominds.com/contact-us (mailto); MX OK (O365)
+,Divami Design Labs,info@divami.com,Corporate Office,General,Hyderabad,Hyderabad; UX/product design + full-stack dev; VERIFIED printed on divami.com/contact (mailto); MX OK (Google)
+,mroads,reachout@mroads.com,Contact Desk,General,Hyderabad,Hyderabad; recruiting-tech (Panna AI) + software services; VERIFIED printed on mroads.com/contact (mailto); MX OK (Google)
+,Tvarana,info@tvarana.com,Corporate Office,General,Hyderabad,Hyderabad; software/ServiceNow/data dev; VERIFIED printed on tvarana.com/contact-us (mailto); MX OK (O365)
+,Nvish Solutions,sales@nvish.com,Sales Team,Sales,Hyderabad,Hyderabad; IT services/analytics/automation; VERIFIED printed on nvish.com/contact-us (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -144,3 +144,4 @@
 ,Algoleap Technologies,contact@algoleap.com,Contact Desk,General,Hyderabad,"Hyderabad (Cyber Gateway, HITEC City); digital/data/AI engineering services; VERIFIED printed on algoleap.com (mailto); MX OK (O365)"
 ,Keansa Solutions,info@keansa.com,Corporate Office,General,Hyderabad,"Hyderabad (HITEC City, Manjeera Trinity); data quality/analytics & IT services; VERIFIED printed on keansa.com/contact-us (mailto); MX OK (O365)"
 ,Haystek Technologies,hr@haystek.com,HR Desk,Recruitment,Hyderabad,Hyderabad (Madhapur); web/mobile app & software dev; VERIFIED printed on haystek.com (mailto); MX OK (Google)
+,Vaakruthi Software Solutions,info@vaakruthi.co.in,Corporate Office,General,Hyderabad,"Hyderabad (Ameerpet, Aditya Trade Center); web/mobile/software dev & staffing; VERIFIED printed on vaakruthi.com (mailto, vaakruthi.co.in); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -138,3 +138,4 @@
 ,Param.ai,sales@param.ai,Sales Team,Sales,Hyderabad,Hyderabad (Gachibowli); AI recruitment/talent-intelligence SaaS; VERIFIED printed on param.ai footer (mailto); MX OK (Google)
 ,ekincare,careers@ekincare.com,Careers Desk,Recruitment,Hyderabad,Hyderabad (HQ - engineering/clinical ops); corporate health-benefits SaaS platform; VERIFIED printed on ekincare.com (mailto); MX OK (O365)
 ,APPIT Software Solutions,info@appitsoftware.com,Corporate Office,General,Hyderabad,"Hyderabad (HQ, Gachibowli); fleet/logistics ERP & custom software products; VERIFIED printed on appitsoftware.com (mailto); MX OK (O365)"
+,CloudAce Technologies,info@cloudacetechnologies.com,Corporate Office,General,Hyderabad,"Hyderabad (Madhapur); Google Cloud partner, cloud consulting & dev; VERIFIED printed on cloudacetechnologies.com (mailto); MX OK (Hostinger)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -52,3 +52,5 @@
 ,Miracle Software Systems,info@miraclesoft.com,Corporate Office,General,Hyderabad,Novi HQ + large Hyderabad delivery center; integration/cloud/digital; VERIFIED printed on miraclesoft.com/contact-us (mailto); MX OK
 ,Aptagrim,info@aptagrim.com,Corporate Office,General,Hyderabad,Hyderabad; data analytics/SAP/cloud services; VERIFIED printed on aptagrim.com/contact-us (mailto); MX OK (O365)
 ,NicheBit Softech,info@nichebit.com,Corporate Office,General,Hyderabad,Hyderabad; software/web/mobile dev; VERIFIED printed on nichebit.com/contact-us (mailto); MX OK (Google)
+,Pyramid SoftSol,careers@pyramidinc.com,Careers Desk,Recruitment,Hyderabad,"Hyderabad (Madhapur, Hi-Tech City); enterprise software/QA/cloud; VERIFIED printed on pyramidinc.com/india/openings (mailto); MX OK (O365)"
+,Honey Soft Solutions,info@honeysoftsolutions.in,Corporate Office,General,Hyderabad,Hyderabad (Dilsukhnagar); web/software dev; VERIFIED printed on honeysoftsolutions.in (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -79,3 +79,4 @@
 ,Conquerors Tech,hr@conquerorstech.net,HR Desk,Recruitment,Hyderabad,Hyderabad; custom software/web/mobile dev; VERIFIED printed on conquerorstech.net/contact-us (mailto); MX OK (Google)
 ,iMatrix Solutions,info@imatrixsolutions.com,Corporate Office,General,Hyderabad,Hyderabad (Dilsukhnagar); web design/dev & SEO; VERIFIED printed on imatrixsolutions.com/contact-us (mailto); MX OK (Google)
 ,Trysol Global Services,info@trysol.com,Corporate Office,General,Hyderabad,"Hyderabad (Gachibowli); app/web dev, cloud & IT consulting; VERIFIED printed on trysol.com (mailto); MX OK (O365)"
+,Frugal Testing,careers@frugaltesting.com,Careers Desk,Recruitment,Hyderabad,Hyderabad; QA/software testing services; VERIFIED printed on frugaltesting.com/contact-us (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -153,3 +153,4 @@
 ,Adepto Geoinformatics,info@adeptogeoit.com,Corporate Office,General,Hyderabad,"Hyderabad (Banjara Hills); GIS/geospatial IT, photogrammetry & digital image processing; VERIFIED printed on adeptogeoit.com (mailto); MX OK (O365)"
 ,ASTROC AS Technology,info@astrocastech.in,Corporate Office,General,Hyderabad,Hyderabad (Uppal Industrial Park); autonomous drones/UGVs & AI autonomy deep-tech; VERIFIED printed on astrocastech.in (mailto); MX OK (Google)
 ,NaPanta,support@napanta.com,Contact Desk,General,Hyderabad,Hyderabad (Somajiguda); agri-advisory/farm management SaaS app; VERIFIED printed on napanta.com (mailto); MX OK (Zoho)
+,Thanos Technologies,contact@thanos.in,Contact Desk,General,Hyderabad,Hyderabad (per StartupHyderabad dir); agri-drone & precision-ag tech; VERIFIED printed on thanos.in (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -105,3 +105,4 @@
 ,IIC Technologies,info@iictechnologies.com,Corporate Office,General,Hyderabad,Hyderabad (HQ); geospatial/hydrographic & GIS software services; VERIFIED printed on iictechnologies.com (mailto); MX OK (O365)
 ,Knack Systems,careers@knacksystems.com,Careers Desk,Recruitment,Hyderabad,Hyderabad (Kukatpally); SAP CX/enterprise consulting & implementation; VERIFIED printed on knacksystems.com/contact-us (mailto); MX OK (Google)
 ,Versatile Mobitech,hr@versatilemobitech.com,HR Desk,Recruitment,Hyderabad,Hyderabad (Kondapur); web/mobile app & ecommerce dev; VERIFIED printed on versatilemobitech.com/contact-us (mailto); MX OK (Google)
+,KBK Business Solutions,info@kbkbusinesssolutions.com,Corporate Office,General,Hyderabad,Hyderabad; web development & digital marketing agency; VERIFIED printed on kbkbusinesssolutions.com (mailto); MX OK (one.com)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -111,3 +111,4 @@
 ,AiFA Labs,info@aifalabs.com,Corporate Office,General,Hyderabad,Hyderabad (Kondapur); enterprise AI/GenAI platforms & IT services; VERIFIED printed on aifalabs.com (mailto); MX OK (O365)
 ,FindErnest,info@findernest.com,Corporate Office,General,Hyderabad,Hyderabad (per MobileAppDaily dir + India registration); data/AI/cloud engineering & talent; VERIFIED printed on findernest.com (mailto); MX OK (O365)
 ,Lahari Technologies,support@laharitechnologies.com,Contact Desk,General,Hyderabad,Hyderabad (A.S. Rao Nagar); web/mobile app dev & IT services; VERIFIED printed on laharitechnologies.com/contact-us (mailto); MX OK
+,Premier Info City,hr@premierinfocity.com,HR Desk,Recruitment,Hyderabad,"Hyderabad (Kavuri Hills, Jubilee Hills); mobile app dev & IT staffing; VERIFIED printed on premierinfocity.com/contact (mailto); MX OK"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -99,3 +99,4 @@
 ,ValueMomentum,ContactNJ@valuemomentum.com,Contact Desk,General,Hyderabad,"Hyderabad (Gachibowli, ValueMomentum Towers) major dev center; insurance/BFSI software & engineering; VERIFIED printed on valuemomentum.com/contact (mailto, US contact desk alias); MX OK (O365)"
 ,Cambridge Technology Enterprises,sales@ctepl.com,Sales Team,Sales,Hyderabad,"Hyderabad (Madhapur, HQ; BSE-listed); AI/cloud/digital transformation services; VERIFIED printed on ctepl.com (mailto); MX OK (O365)"
 ,WebNapp Studio,sales@webnappstudio.in,Sales Team,Sales,Hyderabad,Hyderabad (Kondapur); Shopify/web & app development; VERIFIED printed on hyderabad.webnappstudio.in (mailto); MX OK (StackMail)
+,Jeevan Scientific Technology,info@jeevanscientific.com,Corporate Office,General,Hyderabad,Hyderabad (Lanco Hills); clinical research/pharmacovigilance IT & software; VERIFIED printed on jeevanscientific.com (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -66,3 +66,5 @@
 ,USM Business Systems,sales@usmsystems.com,Sales Team,Sales,Hyderabad,"Hyderabad delivery center (US HQ, Virginia); IT staffing/software/AI; VERIFIED printed on usmsystems.com/contact-us (mailto); MX OK (O365)"
 ,Ogre Head Studio,support@ogrehead.com,Contact Desk,General,Hyderabad,"Hyderabad; indie video game studio (Asura); VERIFIED printed on ogreheadstudio.com footer (mailto, ogrehead.com domain); MX OK"
 ,GameNexa Studios,info@gamenexa.com,Corporate Office,General,Hyderabad,Hyderabad (HQ); mobile app/game dev & digital marketing; VERIFIED printed on gamenexa.com (mailto); MX OK
+,AppShark Software,sales@appshark.com,Sales Team,Sales,Hyderabad,Hyderabad; Salesforce/mobile/enterprise app dev; VERIFIED printed on appshark.com/contact-us (mailto); MX OK (Google)
+,Vikisol Technologies,connect@vikisol.in,Contact Desk,General,Hyderabad,Hyderabad (Mindspace) + Bengaluru; Salesforce/SAP/ServiceNow consulting; VERIFIED printed on vikisol.in/contact (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -54,3 +54,4 @@
 ,NicheBit Softech,info@nichebit.com,Corporate Office,General,Hyderabad,Hyderabad; software/web/mobile dev; VERIFIED printed on nichebit.com/contact-us (mailto); MX OK (Google)
 ,Pyramid SoftSol,careers@pyramidinc.com,Careers Desk,Recruitment,Hyderabad,"Hyderabad (Madhapur, Hi-Tech City); enterprise software/QA/cloud; VERIFIED printed on pyramidinc.com/india/openings (mailto); MX OK (O365)"
 ,Honey Soft Solutions,info@honeysoftsolutions.in,Corporate Office,General,Hyderabad,Hyderabad (Dilsukhnagar); web/software dev; VERIFIED printed on honeysoftsolutions.in (mailto); MX OK (Google)
+,Autorox,stayhappy@autorox.co,Contact Desk,General,Hyderabad,"Hyderabad (Gachibowli); AI garage/auto workshop management SaaS; VERIFIED printed on autorox.ai footer (mailto, autorox.co domain); MX OK (Google)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -126,3 +126,4 @@
 ,The Go-To Guy,enquiry@thegotoguy.co,Contact Desk,General,Hyderabad,Hyderabad (+Pune/Dubai); web/app dev & digital marketing agency; VERIFIED printed on thegotoguy.co/contact-us (mailto); MX OK (O365)
 ,Phoxsite,hello@phoxsite.com,Contact Desk,General,Hyderabad,Hyderabad; web design/development & digital services; VERIFIED printed on phoxsite.com/contact-us (mailto); MX OK
 ,GBB (Global Bees Bots),hello@gbb.co.in,Contact Desk,General,Hyderabad,Hyderabad (Ameerpet); AWS/cloud consulting & migration partner; VERIFIED printed on gbb.co.in/contact-us (mailto); MX OK
+,BeyondScale Technologies,hello@beyondscale.tech,Contact Desk,General,Hyderabad,"Hyderabad (office; US HQ Jupiter FL); AWS partner, cloud/DevOps & AI product engineering; VERIFIED printed on beyondscale.tech (mailto); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -104,3 +104,4 @@
 ,Grene Robotics,workwithus@grenerobotics.com,Careers Desk,Recruitment,Hyderabad,"Hyderabad (Gachibowli, HQ); autonomous systems/AI drone-defense (Indrajaal); VERIFIED printed on grenerobotics.com/contact-us (mailto); MX OK (Google)"
 ,IIC Technologies,info@iictechnologies.com,Corporate Office,General,Hyderabad,Hyderabad (HQ); geospatial/hydrographic & GIS software services; VERIFIED printed on iictechnologies.com (mailto); MX OK (O365)
 ,Knack Systems,careers@knacksystems.com,Careers Desk,Recruitment,Hyderabad,Hyderabad (Kukatpally); SAP CX/enterprise consulting & implementation; VERIFIED printed on knacksystems.com/contact-us (mailto); MX OK (Google)
+,Versatile Mobitech,hr@versatilemobitech.com,HR Desk,Recruitment,Hyderabad,Hyderabad (Kondapur); web/mobile app & ecommerce dev; VERIFIED printed on versatilemobitech.com/contact-us (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -86,3 +86,5 @@
 ,Tek Leaders,info@tekleaders.com,Corporate Office,General,Hyderabad,Hyderabad; IT services/data & cloud; VERIFIED info@ mailto on tekleaders.com; MX OK (O365)
 ,Waytowebs,info@waytowebs.com,Corporate Office,General,Hyderabad,Hyderabad; web/app/UI-UX design & development; VERIFIED printed on waytowebs.com (mailto); MX OK (Google)
 ,CreditMitra,support@creditmitra.in,Contact Desk,General,Hyderabad,"Hyderabad (HQ); lending/insurance fintech; VERIFIED printed on creditmitra.in/contact-us (mailto), support alias; MX OK (Google)"
+,Digital Eyecon,info@digitaleyecon.com,Corporate Office,General,Hyderabad,Hyderabad; web/mobile app dev & digital marketing; VERIFIED printed on digitaleyecon.com/contact-us (mailto); MX OK (Zoho)
+,ThreeAtoms,contact@threeatoms.com,Contact Desk,General,Hyderabad,Hyderabad (Kukatpally); web/app software dev; VERIFIED printed on threeatoms.com (mailto); MX OK (Zoho)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -140,3 +140,4 @@
 ,APPIT Software Solutions,info@appitsoftware.com,Corporate Office,General,Hyderabad,"Hyderabad (HQ, Gachibowli); fleet/logistics ERP & custom software products; VERIFIED printed on appitsoftware.com (mailto); MX OK (O365)"
 ,CloudAce Technologies,info@cloudacetechnologies.com,Corporate Office,General,Hyderabad,"Hyderabad (Madhapur); Google Cloud partner, cloud consulting & dev; VERIFIED printed on cloudacetechnologies.com (mailto); MX OK (Hostinger)"
 ,Apxor,contact@apxor.com,Contact Desk,General,Hyderabad,Hyderabad (Kondapur); mobile product-analytics & nudging SaaS; VERIFIED printed on apxor.com/contact-us (mailto); MX OK (Google)
+,Modak Analytics,sales@modak.com,Sales Team,Sales,Hyderabad,"Hyderabad (Nanakramguda, Financial District delivery center); data engineering/management platform; VERIFIED printed on modak.com/contact-us (mailto); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -125,3 +125,4 @@
 ,Pride Web Technologies,support@pridewebtech.com,Contact Desk,General,Hyderabad,Hyderabad (Domalguda); web/app dev & digital marketing; VERIFIED printed on pridewebtech.com/contact-us (mailto); MX OK (Google)
 ,The Go-To Guy,enquiry@thegotoguy.co,Contact Desk,General,Hyderabad,Hyderabad (+Pune/Dubai); web/app dev & digital marketing agency; VERIFIED printed on thegotoguy.co/contact-us (mailto); MX OK (O365)
 ,Phoxsite,hello@phoxsite.com,Contact Desk,General,Hyderabad,Hyderabad; web design/development & digital services; VERIFIED printed on phoxsite.com/contact-us (mailto); MX OK
+,GBB (Global Bees Bots),hello@gbb.co.in,Contact Desk,General,Hyderabad,Hyderabad (Ameerpet); AWS/cloud consulting & migration partner; VERIFIED printed on gbb.co.in/contact-us (mailto); MX OK

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -91,3 +91,4 @@
 ,Toyaja,sales@toyaja.com,Sales Team,Sales,Hyderabad,Hyderabad; web/mobile/enterprise software dev; VERIFIED printed on toyaja.com/contact-us (mailto); MX OK (Google)
 ,SlashMonk,info@slashmonk.com,Corporate Office,General,Hyderabad,Hyderabad; product/web engineering; VERIFIED printed on slashmonk.com/contact (mailto); MX OK
 ,DigitalOps,hello@digitalops.in,Corporate Office,General,Hyderabad,Hyderabad; web/app dev & digital solutions; VERIFIED printed on digitalops.in/contact-us (mailto); MX OK (Hostinger)
+,Quixy (VividMinds Technologies),careers@quixy.com,Careers Desk,Recruitment,Hyderabad,"Hyderabad (Nanakramguda, Financial District); no-code/low-code app development SaaS platform; VERIFIED printed on quixy.com/contact (mailto); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -124,3 +124,4 @@
 ,Geekschip,info@geekschip.com,Corporate Office,General,Hyderabad,"Hyderabad (Kavuri Hills, Madhapur); digital marketing & web/app dev; VERIFIED printed on geekschip.com/contact-us (mailto); MX OK (O365)"
 ,Pride Web Technologies,support@pridewebtech.com,Contact Desk,General,Hyderabad,Hyderabad (Domalguda); web/app dev & digital marketing; VERIFIED printed on pridewebtech.com/contact-us (mailto); MX OK (Google)
 ,The Go-To Guy,enquiry@thegotoguy.co,Contact Desk,General,Hyderabad,Hyderabad (+Pune/Dubai); web/app dev & digital marketing agency; VERIFIED printed on thegotoguy.co/contact-us (mailto); MX OK (O365)
+,Phoxsite,hello@phoxsite.com,Contact Desk,General,Hyderabad,Hyderabad; web design/development & digital services; VERIFIED printed on phoxsite.com/contact-us (mailto); MX OK

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -113,3 +113,4 @@
 ,Lahari Technologies,support@laharitechnologies.com,Contact Desk,General,Hyderabad,Hyderabad (A.S. Rao Nagar); web/mobile app dev & IT services; VERIFIED printed on laharitechnologies.com/contact-us (mailto); MX OK
 ,Premier Info City,hr@premierinfocity.com,HR Desk,Recruitment,Hyderabad,"Hyderabad (Kavuri Hills, Jubilee Hills); mobile app dev & IT staffing; VERIFIED printed on premierinfocity.com/contact (mailto); MX OK"
 ,Conrep Solutions,sales@conrep.com,Sales Team,Sales,Hyderabad,"Hyderabad office (Jubilee Hills, per directory; also US); PSA/staffing & recruiting software product; VERIFIED printed on conrep.com (mailto); MX OK"
+,Web Synergies,sales@websynergies.com,Sales Team,Sales,Hyderabad,Hyderabad (Banjara Hills; India arm of Singapore firm); digital transformation/web/cloud dev; VERIFIED printed on websynergies.com/contact-us (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -156,3 +156,4 @@
 ,Thanos Technologies,contact@thanos.in,Contact Desk,General,Hyderabad,Hyderabad (per StartupHyderabad dir); agri-drone & precision-ag tech; VERIFIED printed on thanos.in (mailto); MX OK (Google)
 ,Tutorials Point,media@tutorialspoint.com,Contact Desk,General,Hyderabad,"Hyderabad (Kavuri Hills, Madhapur); ed-content/e-learning platform; VERIFIED printed on tutorialspoint.com/about/contact_us (mailto); MX OK (Google)"
 ,360DigiTMG,info@360digitmg.com,Corporate Office,General,Hyderabad,Hyderabad (Madhapur); data-science/AI training & analytics; VERIFIED printed on 360digitmg.com/contact-us (mailto); MX OK (Google)
+,IncNut Digital,support@incnut.com,Contact Desk,General,Hyderabad,"Hyderabad (Kondapur); digital media/D2C tech (StyleCraze, MomJunction, Vedix); VERIFIED printed on incnut.com (mailto); MX OK (Google)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -123,3 +123,4 @@
 ,500apps,support@500apps.com,Contact Desk,General,Hyderabad,Hyderabad (Madhapur; +Dubai); all-in-one business SaaS suite (Aumtech); VERIFIED printed on 500apps.com/contact-us (mailto); MX OK (Google)
 ,Geekschip,info@geekschip.com,Corporate Office,General,Hyderabad,"Hyderabad (Kavuri Hills, Madhapur); digital marketing & web/app dev; VERIFIED printed on geekschip.com/contact-us (mailto); MX OK (O365)"
 ,Pride Web Technologies,support@pridewebtech.com,Contact Desk,General,Hyderabad,Hyderabad (Domalguda); web/app dev & digital marketing; VERIFIED printed on pridewebtech.com/contact-us (mailto); MX OK (Google)
+,The Go-To Guy,enquiry@thegotoguy.co,Contact Desk,General,Hyderabad,Hyderabad (+Pune/Dubai); web/app dev & digital marketing agency; VERIFIED printed on thegotoguy.co/contact-us (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -150,3 +150,4 @@
 ,Team Erudite,accounts@teamerudite.com,Contact Desk,General,Hyderabad,Hyderabad (Kukatpally); web/mobile app & software dev; VERIFIED printed on teamerudite.com/contact-us (mailto); MX OK (Google)
 ,Magnaquest Technologies,sales@magnaquest.com,Sales Team,Sales,Hyderabad,Hyderabad (Madhapur); subscription/billing & OTT monetization software product (Sure); VERIFIED printed on magnaquest.com (mailto); MX OK (O365)
 ,Helical IT Solutions,nitin@helicaltech.com,Nitin Sagar,Co-Founder / Director,Hyderabad,Hyderabad (Somajiguda); named-person contact published as mailto on helicaltech.com; MX OK (O365)
+,Adepto Geoinformatics,info@adeptogeoit.com,Corporate Office,General,Hyderabad,"Hyderabad (Banjara Hills); GIS/geospatial IT, photogrammetry & digital image processing; VERIFIED printed on adeptogeoit.com (mailto); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -63,3 +63,4 @@
 ,Codetru,queries@codetru.com,Contact Desk,General,Hyderabad,Hyderabad; software/web/mobile & AI dev; VERIFIED printed on codetru.com (mailto); MX OK (O365)
 ,Tech Cloud ERP,sales@techclouderp.com,Sales Team,Sales,Hyderabad,"Hyderabad (Madhapur, Kavuri Hills); cloud ERP software product; VERIFIED printed on techclouderp.com/contact-us (mailto); MX OK (Google)"
 ,SYOFT,info@syoft.com,Corporate Office,General,Hyderabad,Hyderabad; mobile app/web/low-code dev; VERIFIED printed on syoft.com (mailto); MX OK (Google)
+,USM Business Systems,sales@usmsystems.com,Sales Team,Sales,Hyderabad,"Hyderabad delivery center (US HQ, Virginia); IT staffing/software/AI; VERIFIED printed on usmsystems.com/contact-us (mailto); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -120,3 +120,4 @@
 ,HSB Infotech,info@hsbinfotech.com,Corporate Office,General,Hyderabad,"Hyderabad (Cyber Towers, Hitech City); custom software/web/mobile dev; VERIFIED printed on hsbinfotech.com/contact-us (mailto); MX OK (O365)"
 ,Tech Tree,info@techtree.in,Corporate Office,General,Hyderabad,Hyderabad (Uppal); custom software/web/mobile dev; VERIFIED printed on techtree.in/contact (mailto); MX OK (Hostinger)
 ,Pengwin Solutions,hyderabad@pengwinsolutions.com,Hyderabad Branch,General,Hyderabad,Hyderabad (Gachibowli); web/mobile app & custom software dev; VERIFIED printed on pengwinsolutions.com/contact-us (Hyderabad-branch mailto); MX OK (Hostinger)
+,500apps,support@500apps.com,Contact Desk,General,Hyderabad,Hyderabad (Madhapur; +Dubai); all-in-one business SaaS suite (Aumtech); VERIFIED printed on 500apps.com/contact-us (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -80,3 +80,5 @@
 ,iMatrix Solutions,info@imatrixsolutions.com,Corporate Office,General,Hyderabad,Hyderabad (Dilsukhnagar); web design/dev & SEO; VERIFIED printed on imatrixsolutions.com/contact-us (mailto); MX OK (Google)
 ,Trysol Global Services,info@trysol.com,Corporate Office,General,Hyderabad,"Hyderabad (Gachibowli); app/web dev, cloud & IT consulting; VERIFIED printed on trysol.com (mailto); MX OK (O365)"
 ,Frugal Testing,careers@frugaltesting.com,Careers Desk,Recruitment,Hyderabad,Hyderabad; QA/software testing services; VERIFIED printed on frugaltesting.com/contact-us (mailto); MX OK (Google)
+,Navayuga Infotech,careers@navayugainfotech.com,Careers Desk,Recruitment,Hyderabad,Hyderabad (HQ); enterprise software/IT services; VERIFIED printed on navayugainfotech.com (mailto); MX OK (O365)
+,DataSpeaks,hello@dataspeaks.co,Contact Desk,General,Hyderabad,Hyderabad; data engineering/analytics/AI services; VERIFIED printed on dataspeaks.co/contact (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -71,3 +71,4 @@
 ,MicroPyramid,hello@micropyramid.com,Contact Desk,General,Hyderabad,Hyderabad (KPHB); Python/Django/Salesforce & cloud dev; VERIFIED printed on micropyramid.com/contact (mailto); MX OK (Google)
 ,Veritis Group,connect@veritis.com,Contact Desk,General,Hyderabad,Hyderabad; DevOps/cloud/IT consulting (US+Hyd); VERIFIED printed on veritis.com/contact (mailto); MX OK (O365)
 ,Devathon,hello@devathon.com,Contact Desk,General,Hyderabad,Hyderabad; product design & software dev; VERIFIED printed on devathon.com/contact (mailto); MX OK (Google)
+,Rapid Circuitry,contact@rapidcircuitry.com,Contact Desk,General,Hyderabad,Hyderabad (Gachibowli); PCB design/embedded firmware/IoT product dev; VERIFIED printed on rapidcircuitry.com/contact (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -132,3 +132,4 @@
 ,Helical IT Solutions,nikhilesh@helicaltech.com,Nikhilesh (contact),General,Hyderabad,Hyderabad (Somajiguda); open-source BI/data warehousing & analytics; VERIFIED published contact mailto on helicaltech.com; MX OK (O365)
 ,Threshold Software Solutions,info@thresholdsoft.com,Corporate Office,General,Hyderabad,Hyderabad (Jubilee Hills); software dev & IT services; VERIFIED printed on thresholdsoft.com (mailto); MX OK (Google)
 ,Runo,care@runo.ai,Contact Desk,General,Hyderabad,"Hyderabad (Cyber Towers, HITEC City); call-management/CRM SaaS product; VERIFIED printed on runo.ai/contact (mailto); MX OK (Google)"
+,FreJun,hello@frejun.com,Contact Desk,General,Hyderabad,"Hyderabad (CIE@IIIT-H, Gachibowli); virtual-calling/telephony SaaS product; VERIFIED printed on frejun.com/contact-us (mailto); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -118,3 +118,4 @@
 ,Amigo Creatz,connect@amigocreatz.in,Contact Desk,General,Hyderabad,Hyderabad (Banjara Hills); web/app dev & digital marketing; VERIFIED printed on amigocreatz.in (mailto); MX OK (Hostinger)
 ,Seven Web Tech,info@sevenwebtech.com,Corporate Office,General,Hyderabad,Hyderabad (Hyderguda); web/app/ecommerce dev; VERIFIED printed on sevenwebtech.com (mailto); MX OK (Hostinger)
 ,HSB Infotech,info@hsbinfotech.com,Corporate Office,General,Hyderabad,"Hyderabad (Cyber Towers, Hitech City); custom software/web/mobile dev; VERIFIED printed on hsbinfotech.com/contact-us (mailto); MX OK (O365)"
+,Tech Tree,info@techtree.in,Corporate Office,General,Hyderabad,Hyderabad (Uppal); custom software/web/mobile dev; VERIFIED printed on techtree.in/contact (mailto); MX OK (Hostinger)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -50,3 +50,4 @@
 ,InfoVision,info@infovision.com,Corporate Office,General,Hyderabad,Hyderabad+Dallas; digital/cloud/data IT services; VERIFIED printed on infovision.com/contact-us (mailto); MX OK (Barracuda)
 ,Tech Vedika,info@techvedika.com,Corporate Office,General,Hyderabad,Hyderabad HQ; AI/cloud/product engineering; VERIFIED printed on techvedika.com/contact (mailto); MX OK (O365)
 ,Miracle Software Systems,info@miraclesoft.com,Corporate Office,General,Hyderabad,Novi HQ + large Hyderabad delivery center; integration/cloud/digital; VERIFIED printed on miraclesoft.com/contact-us (mailto); MX OK
+,Aptagrim,info@aptagrim.com,Corporate Office,General,Hyderabad,Hyderabad; data analytics/SAP/cloud services; VERIFIED printed on aptagrim.com/contact-us (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -57,3 +57,4 @@
 ,Autorox,stayhappy@autorox.co,Contact Desk,General,Hyderabad,"Hyderabad (Gachibowli); AI garage/auto workshop management SaaS; VERIFIED printed on autorox.ai footer (mailto, autorox.co domain); MX OK (Google)"
 ,Ahex Technologies,hr@ahex.co.in,HR Desk,Recruitment,Hyderabad,"Hyderabad; web/mobile/AI software dev; VERIFIED printed on ahex.co/contact for HR (mailto, ahex.co.in domain); MX OK (Yahoo Biz)"
 ,SmartX Solutions,business@smartxsolutions.in,Contact Desk,General,Hyderabad,Hyderabad (New Malakpet); web/app/SaaS dev agency; VERIFIED printed on smartxsolutions.in/contact-us (mailto); MX OK (Zoho)
+,EasyQuickWeb,info@easyquickweb.com,Corporate Office,General,Hyderabad,Hyderabad; web design/dev & digital agency; VERIFIED printed on easyquickweb.com/contact-us (mailto); MX OK (Hostinger)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -152,3 +152,4 @@
 ,Helical IT Solutions,nitin@helicaltech.com,Nitin Sagar,Co-Founder / Director,Hyderabad,Hyderabad (Somajiguda); named-person contact published as mailto on helicaltech.com; MX OK (O365)
 ,Adepto Geoinformatics,info@adeptogeoit.com,Corporate Office,General,Hyderabad,"Hyderabad (Banjara Hills); GIS/geospatial IT, photogrammetry & digital image processing; VERIFIED printed on adeptogeoit.com (mailto); MX OK (O365)"
 ,ASTROC AS Technology,info@astrocastech.in,Corporate Office,General,Hyderabad,Hyderabad (Uppal Industrial Park); autonomous drones/UGVs & AI autonomy deep-tech; VERIFIED printed on astrocastech.in (mailto); MX OK (Google)
+,NaPanta,support@napanta.com,Contact Desk,General,Hyderabad,Hyderabad (Somajiguda); agri-advisory/farm management SaaS app; VERIFIED printed on napanta.com (mailto); MX OK (Zoho)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -107,3 +107,4 @@
 ,Versatile Mobitech,hr@versatilemobitech.com,HR Desk,Recruitment,Hyderabad,Hyderabad (Kondapur); web/mobile app & ecommerce dev; VERIFIED printed on versatilemobitech.com/contact-us (mailto); MX OK (Google)
 ,KBK Business Solutions,info@kbkbusinesssolutions.com,Corporate Office,General,Hyderabad,Hyderabad; web development & digital marketing agency; VERIFIED printed on kbkbusinesssolutions.com (mailto); MX OK (one.com)
 ,Origin Softwares,info@originsoftwares.com,Corporate Office,General,Hyderabad,Hyderabad (Masab Tank); custom software/web/mobile dev & training; VERIFIED printed on originsoftwares.com (mailto); MX OK (Google)
+,Charter Global,sales@charterglobal.com,Sales Team,Sales,Hyderabad,Hyderabad delivery center (Madhapur; US HQ Atlanta); IT services/data/AI/ServiceNow; VERIFIED printed on charterglobal.com/contact-us (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -76,3 +76,4 @@
 ,VALSOC Semiconductor,hr@valsocsemi.com,HR Desk,Recruitment,Hyderabad,Hyderabad; VLSI/semiconductor product & design services; VERIFIED printed on valsocsemi.com/contact-us (mailto); MX OK (Google)
 ,Innoit Labs,info@innoitlabs.com,Corporate Office,General,Hyderabad,Hyderabad; web/mobile/cloud software dev; VERIFIED printed on innoitlabs.com (mailto); MX OK (Google)
 ,Analogue IT Solutions,info@analogueitsolutions.com,Corporate Office,General,Hyderabad,Hyderabad; web/app/software dev; VERIFIED printed on analogueitsolutions.com/contact-us (mailto); MX OK
+,Conquerors Tech,hr@conquerorstech.net,HR Desk,Recruitment,Hyderabad,Hyderabad; custom software/web/mobile dev; VERIFIED printed on conquerorstech.net/contact-us (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -127,3 +127,4 @@
 ,Phoxsite,hello@phoxsite.com,Contact Desk,General,Hyderabad,Hyderabad; web design/development & digital services; VERIFIED printed on phoxsite.com/contact-us (mailto); MX OK
 ,GBB (Global Bees Bots),hello@gbb.co.in,Contact Desk,General,Hyderabad,Hyderabad (Ameerpet); AWS/cloud consulting & migration partner; VERIFIED printed on gbb.co.in/contact-us (mailto); MX OK
 ,BeyondScale Technologies,hello@beyondscale.tech,Contact Desk,General,Hyderabad,"Hyderabad (office; US HQ Jupiter FL); AWS partner, cloud/DevOps & AI product engineering; VERIFIED printed on beyondscale.tech (mailto); MX OK (O365)"
+,DataTerminal,contact@dataterminal.co,Contact Desk,General,Hyderabad,Hyderabad (Financial District); AI/data-engineering services & products; VERIFIED printed on dataterminal.co/contact (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -94,3 +94,4 @@
 ,Quixy (VividMinds Technologies),careers@quixy.com,Careers Desk,Recruitment,Hyderabad,"Hyderabad (Nanakramguda, Financial District); no-code/low-code app development SaaS platform; VERIFIED printed on quixy.com/contact (mailto); MX OK (O365)"
 ,Landeed (John Salt Pvt Ltd),customers@landeed.com,Contact Desk,General,Hyderabad,"Hyderabad (HITEC City); property-records/title-search SaaS (YC); VERIFIED printed on landeed.com/contact-us (mailto), support alias; MX OK (Google)"
 ,Agasthya App Labs,info@agasthyaapplabs.com,Corporate Office,General,Hyderabad,Hyderabad (one of its offices; also Bengaluru); mobile/web app development; VERIFIED printed on agasthyaapplabs.com (mailto); MX OK (O365)
+,myMoneyKarma,askus@mymoneykarma.com,Contact Desk,General,Hyderabad,"Hyderabad (T-Hub); personal-finance/credit fintech; VERIFIED printed on moneykarma.com (mailto), support alias; MX OK (Google)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -98,3 +98,4 @@
 ,CitiusTech,info@citiustech.com,Corporate Office,General,Hyderabad,"Hyderabad (HITEC City, Madhapur) delivery center; healthcare IT/consulting & engineering; VERIFIED printed on citiustech.com/contact-us (mailto); MX OK (O365)"
 ,ValueMomentum,ContactNJ@valuemomentum.com,Contact Desk,General,Hyderabad,"Hyderabad (Gachibowli, ValueMomentum Towers) major dev center; insurance/BFSI software & engineering; VERIFIED printed on valuemomentum.com/contact (mailto, US contact desk alias); MX OK (O365)"
 ,Cambridge Technology Enterprises,sales@ctepl.com,Sales Team,Sales,Hyderabad,"Hyderabad (Madhapur, HQ; BSE-listed); AI/cloud/digital transformation services; VERIFIED printed on ctepl.com (mailto); MX OK (O365)"
+,WebNapp Studio,sales@webnappstudio.in,Sales Team,Sales,Hyderabad,Hyderabad (Kondapur); Shopify/web & app development; VERIFIED printed on hyderabad.webnappstudio.in (mailto); MX OK (StackMail)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -145,3 +145,4 @@
 ,Keansa Solutions,info@keansa.com,Corporate Office,General,Hyderabad,"Hyderabad (HITEC City, Manjeera Trinity); data quality/analytics & IT services; VERIFIED printed on keansa.com/contact-us (mailto); MX OK (O365)"
 ,Haystek Technologies,hr@haystek.com,HR Desk,Recruitment,Hyderabad,Hyderabad (Madhapur); web/mobile app & software dev; VERIFIED printed on haystek.com (mailto); MX OK (Google)
 ,Vaakruthi Software Solutions,info@vaakruthi.co.in,Corporate Office,General,Hyderabad,"Hyderabad (Ameerpet, Aditya Trade Center); web/mobile/software dev & staffing; VERIFIED printed on vaakruthi.com (mailto, vaakruthi.co.in); MX OK (O365)"
+,CentoTech Services,info@centotech.com,Corporate Office,General,Hyderabad,"Hyderabad (Gachibowli); web/mobile app & software dev; VERIFIED printed on centotech.in (mailto, centotech.com); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -110,3 +110,4 @@
 ,Charter Global,sales@charterglobal.com,Sales Team,Sales,Hyderabad,Hyderabad delivery center (Madhapur; US HQ Atlanta); IT services/data/AI/ServiceNow; VERIFIED printed on charterglobal.com/contact-us (mailto); MX OK (O365)
 ,AiFA Labs,info@aifalabs.com,Corporate Office,General,Hyderabad,Hyderabad (Kondapur); enterprise AI/GenAI platforms & IT services; VERIFIED printed on aifalabs.com (mailto); MX OK (O365)
 ,FindErnest,info@findernest.com,Corporate Office,General,Hyderabad,Hyderabad (per MobileAppDaily dir + India registration); data/AI/cloud engineering & talent; VERIFIED printed on findernest.com (mailto); MX OK (O365)
+,Lahari Technologies,support@laharitechnologies.com,Contact Desk,General,Hyderabad,Hyderabad (A.S. Rao Nagar); web/mobile app dev & IT services; VERIFIED printed on laharitechnologies.com/contact-us (mailto); MX OK

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -114,3 +114,4 @@
 ,Premier Info City,hr@premierinfocity.com,HR Desk,Recruitment,Hyderabad,"Hyderabad (Kavuri Hills, Jubilee Hills); mobile app dev & IT staffing; VERIFIED printed on premierinfocity.com/contact (mailto); MX OK"
 ,Conrep Solutions,sales@conrep.com,Sales Team,Sales,Hyderabad,"Hyderabad office (Jubilee Hills, per directory; also US); PSA/staffing & recruiting software product; VERIFIED printed on conrep.com (mailto); MX OK"
 ,Web Synergies,sales@websynergies.com,Sales Team,Sales,Hyderabad,Hyderabad (Banjara Hills; India arm of Singapore firm); digital transformation/web/cloud dev; VERIFIED printed on websynergies.com/contact-us (mailto); MX OK (O365)
+,Stratosphere IT Services,info@stratosphere.co.in,Corporate Office,General,Hyderabad,Hyderabad (Madhapur); software dev & IT services; VERIFIED printed on stratosphere.co.in (mailto); MX OK

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -97,3 +97,4 @@
 ,myMoneyKarma,askus@mymoneykarma.com,Contact Desk,General,Hyderabad,"Hyderabad (T-Hub); personal-finance/credit fintech; VERIFIED printed on moneykarma.com (mailto), support alias; MX OK (Google)"
 ,CitiusTech,info@citiustech.com,Corporate Office,General,Hyderabad,"Hyderabad (HITEC City, Madhapur) delivery center; healthcare IT/consulting & engineering; VERIFIED printed on citiustech.com/contact-us (mailto); MX OK (O365)"
 ,ValueMomentum,ContactNJ@valuemomentum.com,Contact Desk,General,Hyderabad,"Hyderabad (Gachibowli, ValueMomentum Towers) major dev center; insurance/BFSI software & engineering; VERIFIED printed on valuemomentum.com/contact (mailto, US contact desk alias); MX OK (O365)"
+,Cambridge Technology Enterprises,sales@ctepl.com,Sales Team,Sales,Hyderabad,"Hyderabad (Madhapur, HQ; BSE-listed); AI/cloud/digital transformation services; VERIFIED printed on ctepl.com (mailto); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -141,3 +141,4 @@
 ,CloudAce Technologies,info@cloudacetechnologies.com,Corporate Office,General,Hyderabad,"Hyderabad (Madhapur); Google Cloud partner, cloud consulting & dev; VERIFIED printed on cloudacetechnologies.com (mailto); MX OK (Hostinger)"
 ,Apxor,contact@apxor.com,Contact Desk,General,Hyderabad,Hyderabad (Kondapur); mobile product-analytics & nudging SaaS; VERIFIED printed on apxor.com/contact-us (mailto); MX OK (Google)
 ,Modak Analytics,sales@modak.com,Sales Team,Sales,Hyderabad,"Hyderabad (Nanakramguda, Financial District delivery center); data engineering/management platform; VERIFIED printed on modak.com/contact-us (mailto); MX OK (O365)"
+,Algoleap Technologies,contact@algoleap.com,Contact Desk,General,Hyderabad,"Hyderabad (Cyber Gateway, HITEC City); digital/data/AI engineering services; VERIFIED printed on algoleap.com (mailto); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -68,3 +68,4 @@
 ,GameNexa Studios,info@gamenexa.com,Corporate Office,General,Hyderabad,Hyderabad (HQ); mobile app/game dev & digital marketing; VERIFIED printed on gamenexa.com (mailto); MX OK
 ,AppShark Software,sales@appshark.com,Sales Team,Sales,Hyderabad,Hyderabad; Salesforce/mobile/enterprise app dev; VERIFIED printed on appshark.com/contact-us (mailto); MX OK (Google)
 ,Vikisol Technologies,connect@vikisol.in,Contact Desk,General,Hyderabad,Hyderabad (Mindspace) + Bengaluru; Salesforce/SAP/ServiceNow consulting; VERIFIED printed on vikisol.in/contact (mailto); MX OK (O365)
+,MicroPyramid,hello@micropyramid.com,Contact Desk,General,Hyderabad,Hyderabad (KPHB); Python/Django/Salesforce & cloud dev; VERIFIED printed on micropyramid.com/contact (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -151,3 +151,4 @@
 ,Magnaquest Technologies,sales@magnaquest.com,Sales Team,Sales,Hyderabad,Hyderabad (Madhapur); subscription/billing & OTT monetization software product (Sure); VERIFIED printed on magnaquest.com (mailto); MX OK (O365)
 ,Helical IT Solutions,nitin@helicaltech.com,Nitin Sagar,Co-Founder / Director,Hyderabad,Hyderabad (Somajiguda); named-person contact published as mailto on helicaltech.com; MX OK (O365)
 ,Adepto Geoinformatics,info@adeptogeoit.com,Corporate Office,General,Hyderabad,"Hyderabad (Banjara Hills); GIS/geospatial IT, photogrammetry & digital image processing; VERIFIED printed on adeptogeoit.com (mailto); MX OK (O365)"
+,ASTROC AS Technology,info@astrocastech.in,Corporate Office,General,Hyderabad,Hyderabad (Uppal Industrial Park); autonomous drones/UGVs & AI autonomy deep-tech; VERIFIED printed on astrocastech.in (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -100,3 +100,4 @@
 ,Cambridge Technology Enterprises,sales@ctepl.com,Sales Team,Sales,Hyderabad,"Hyderabad (Madhapur, HQ; BSE-listed); AI/cloud/digital transformation services; VERIFIED printed on ctepl.com (mailto); MX OK (O365)"
 ,WebNapp Studio,sales@webnappstudio.in,Sales Team,Sales,Hyderabad,Hyderabad (Kondapur); Shopify/web & app development; VERIFIED printed on hyderabad.webnappstudio.in (mailto); MX OK (StackMail)
 ,Jeevan Scientific Technology,info@jeevanscientific.com,Corporate Office,General,Hyderabad,Hyderabad (Lanco Hills); clinical research/pharmacovigilance IT & software; VERIFIED printed on jeevanscientific.com (mailto); MX OK (O365)
+,Marut Drones,enquiries@marutdrones.com,Contact Desk,General,Hyderabad,Hyderabad (Madhapur); drone-tech hardware + software/AI platforms; VERIFIED printed on marutdrones.com/contact-us (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -93,3 +93,4 @@
 ,DigitalOps,hello@digitalops.in,Corporate Office,General,Hyderabad,Hyderabad; web/app dev & digital solutions; VERIFIED printed on digitalops.in/contact-us (mailto); MX OK (Hostinger)
 ,Quixy (VividMinds Technologies),careers@quixy.com,Careers Desk,Recruitment,Hyderabad,"Hyderabad (Nanakramguda, Financial District); no-code/low-code app development SaaS platform; VERIFIED printed on quixy.com/contact (mailto); MX OK (O365)"
 ,Landeed (John Salt Pvt Ltd),customers@landeed.com,Contact Desk,General,Hyderabad,"Hyderabad (HITEC City); property-records/title-search SaaS (YC); VERIFIED printed on landeed.com/contact-us (mailto), support alias; MX OK (Google)"
+,Agasthya App Labs,info@agasthyaapplabs.com,Corporate Office,General,Hyderabad,Hyderabad (one of its offices; also Bengaluru); mobile/web app development; VERIFIED printed on agasthyaapplabs.com (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -121,3 +121,4 @@
 ,Tech Tree,info@techtree.in,Corporate Office,General,Hyderabad,Hyderabad (Uppal); custom software/web/mobile dev; VERIFIED printed on techtree.in/contact (mailto); MX OK (Hostinger)
 ,Pengwin Solutions,hyderabad@pengwinsolutions.com,Hyderabad Branch,General,Hyderabad,Hyderabad (Gachibowli); web/mobile app & custom software dev; VERIFIED printed on pengwinsolutions.com/contact-us (Hyderabad-branch mailto); MX OK (Hostinger)
 ,500apps,support@500apps.com,Contact Desk,General,Hyderabad,Hyderabad (Madhapur; +Dubai); all-in-one business SaaS suite (Aumtech); VERIFIED printed on 500apps.com/contact-us (mailto); MX OK (Google)
+,Geekschip,info@geekschip.com,Corporate Office,General,Hyderabad,"Hyderabad (Kavuri Hills, Madhapur); digital marketing & web/app dev; VERIFIED printed on geekschip.com/contact-us (mailto); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -72,3 +72,4 @@
 ,Veritis Group,connect@veritis.com,Contact Desk,General,Hyderabad,Hyderabad; DevOps/cloud/IT consulting (US+Hyd); VERIFIED printed on veritis.com/contact (mailto); MX OK (O365)
 ,Devathon,hello@devathon.com,Contact Desk,General,Hyderabad,Hyderabad; product design & software dev; VERIFIED printed on devathon.com/contact (mailto); MX OK (Google)
 ,Rapid Circuitry,contact@rapidcircuitry.com,Contact Desk,General,Hyderabad,Hyderabad (Gachibowli); PCB design/embedded firmware/IoT product dev; VERIFIED printed on rapidcircuitry.com/contact (mailto); MX OK (O365)
+,MosChip Technologies,contact@moschip.com,Contact Desk,General,Hyderabad,Hyderabad (HQ); semiconductor/VLSI/embedded & IoT design; VERIFIED printed on moschip.com/contact-us (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -103,3 +103,4 @@
 ,Marut Drones,enquiries@marutdrones.com,Contact Desk,General,Hyderabad,Hyderabad (Madhapur); drone-tech hardware + software/AI platforms; VERIFIED printed on marutdrones.com/contact-us (mailto); MX OK (Google)
 ,Grene Robotics,workwithus@grenerobotics.com,Careers Desk,Recruitment,Hyderabad,"Hyderabad (Gachibowli, HQ); autonomous systems/AI drone-defense (Indrajaal); VERIFIED printed on grenerobotics.com/contact-us (mailto); MX OK (Google)"
 ,IIC Technologies,info@iictechnologies.com,Corporate Office,General,Hyderabad,Hyderabad (HQ); geospatial/hydrographic & GIS software services; VERIFIED printed on iictechnologies.com (mailto); MX OK (O365)
+,Knack Systems,careers@knacksystems.com,Careers Desk,Recruitment,Hyderabad,Hyderabad (Kukatpally); SAP CX/enterprise consulting & implementation; VERIFIED printed on knacksystems.com/contact-us (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -139,3 +139,4 @@
 ,ekincare,careers@ekincare.com,Careers Desk,Recruitment,Hyderabad,Hyderabad (HQ - engineering/clinical ops); corporate health-benefits SaaS platform; VERIFIED printed on ekincare.com (mailto); MX OK (O365)
 ,APPIT Software Solutions,info@appitsoftware.com,Corporate Office,General,Hyderabad,"Hyderabad (HQ, Gachibowli); fleet/logistics ERP & custom software products; VERIFIED printed on appitsoftware.com (mailto); MX OK (O365)"
 ,CloudAce Technologies,info@cloudacetechnologies.com,Corporate Office,General,Hyderabad,"Hyderabad (Madhapur); Google Cloud partner, cloud consulting & dev; VERIFIED printed on cloudacetechnologies.com (mailto); MX OK (Hostinger)"
+,Apxor,contact@apxor.com,Contact Desk,General,Hyderabad,Hyderabad (Kondapur); mobile product-analytics & nudging SaaS; VERIFIED printed on apxor.com/contact-us (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -128,3 +128,4 @@
 ,GBB (Global Bees Bots),hello@gbb.co.in,Contact Desk,General,Hyderabad,Hyderabad (Ameerpet); AWS/cloud consulting & migration partner; VERIFIED printed on gbb.co.in/contact-us (mailto); MX OK
 ,BeyondScale Technologies,hello@beyondscale.tech,Contact Desk,General,Hyderabad,"Hyderabad (office; US HQ Jupiter FL); AWS partner, cloud/DevOps & AI product engineering; VERIFIED printed on beyondscale.tech (mailto); MX OK (O365)"
 ,DataTerminal,contact@dataterminal.co,Contact Desk,General,Hyderabad,Hyderabad (Financial District); AI/data-engineering services & products; VERIFIED printed on dataterminal.co/contact (mailto); MX OK (O365)
+,BizAcuity Solutions,solutions@bizacuity.com,Contact Desk,General,Hyderabad,Hyderabad (Madhapur); BI/data analytics & AI consulting; VERIFIED printed on bizacuity.com/contact-us (mailto); MX OK

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -109,3 +109,4 @@
 ,Origin Softwares,info@originsoftwares.com,Corporate Office,General,Hyderabad,Hyderabad (Masab Tank); custom software/web/mobile dev & training; VERIFIED printed on originsoftwares.com (mailto); MX OK (Google)
 ,Charter Global,sales@charterglobal.com,Sales Team,Sales,Hyderabad,Hyderabad delivery center (Madhapur; US HQ Atlanta); IT services/data/AI/ServiceNow; VERIFIED printed on charterglobal.com/contact-us (mailto); MX OK (O365)
 ,AiFA Labs,info@aifalabs.com,Corporate Office,General,Hyderabad,Hyderabad (Kondapur); enterprise AI/GenAI platforms & IT services; VERIFIED printed on aifalabs.com (mailto); MX OK (O365)
+,FindErnest,info@findernest.com,Corporate Office,General,Hyderabad,Hyderabad (per MobileAppDaily dir + India registration); data/AI/cloud engineering & talent; VERIFIED printed on findernest.com (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -112,3 +112,4 @@
 ,FindErnest,info@findernest.com,Corporate Office,General,Hyderabad,Hyderabad (per MobileAppDaily dir + India registration); data/AI/cloud engineering & talent; VERIFIED printed on findernest.com (mailto); MX OK (O365)
 ,Lahari Technologies,support@laharitechnologies.com,Contact Desk,General,Hyderabad,Hyderabad (A.S. Rao Nagar); web/mobile app dev & IT services; VERIFIED printed on laharitechnologies.com/contact-us (mailto); MX OK
 ,Premier Info City,hr@premierinfocity.com,HR Desk,Recruitment,Hyderabad,"Hyderabad (Kavuri Hills, Jubilee Hills); mobile app dev & IT staffing; VERIFIED printed on premierinfocity.com/contact (mailto); MX OK"
+,Conrep Solutions,sales@conrep.com,Sales Team,Sales,Hyderabad,"Hyderabad office (Jubilee Hills, per directory; also US); PSA/staffing & recruiting software product; VERIFIED printed on conrep.com (mailto); MX OK"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -82,3 +82,5 @@
 ,Frugal Testing,careers@frugaltesting.com,Careers Desk,Recruitment,Hyderabad,Hyderabad; QA/software testing services; VERIFIED printed on frugaltesting.com/contact-us (mailto); MX OK (Google)
 ,Navayuga Infotech,careers@navayugainfotech.com,Careers Desk,Recruitment,Hyderabad,Hyderabad (HQ); enterprise software/IT services; VERIFIED printed on navayugainfotech.com (mailto); MX OK (O365)
 ,DataSpeaks,hello@dataspeaks.co,Contact Desk,General,Hyderabad,Hyderabad; data engineering/analytics/AI services; VERIFIED printed on dataspeaks.co/contact (mailto); MX OK (O365)
+,Gleecus TechLabs,hello@gleecus.com,Contact Desk,General,Hyderabad,"Hyderabad; digital/product engineering, AI & cloud; VERIFIED printed on gleecus.com/contact-us (mailto); MX OK (O365)"
+,Tek Leaders,info@tekleaders.com,Corporate Office,General,Hyderabad,Hyderabad; IT services/data & cloud; VERIFIED info@ mailto on tekleaders.com; MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -51,3 +51,4 @@
 ,Tech Vedika,info@techvedika.com,Corporate Office,General,Hyderabad,Hyderabad HQ; AI/cloud/product engineering; VERIFIED printed on techvedika.com/contact (mailto); MX OK (O365)
 ,Miracle Software Systems,info@miraclesoft.com,Corporate Office,General,Hyderabad,Novi HQ + large Hyderabad delivery center; integration/cloud/digital; VERIFIED printed on miraclesoft.com/contact-us (mailto); MX OK
 ,Aptagrim,info@aptagrim.com,Corporate Office,General,Hyderabad,Hyderabad; data analytics/SAP/cloud services; VERIFIED printed on aptagrim.com/contact-us (mailto); MX OK (O365)
+,NicheBit Softech,info@nichebit.com,Corporate Office,General,Hyderabad,Hyderabad; software/web/mobile dev; VERIFIED printed on nichebit.com/contact-us (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -119,3 +119,4 @@
 ,Seven Web Tech,info@sevenwebtech.com,Corporate Office,General,Hyderabad,Hyderabad (Hyderguda); web/app/ecommerce dev; VERIFIED printed on sevenwebtech.com (mailto); MX OK (Hostinger)
 ,HSB Infotech,info@hsbinfotech.com,Corporate Office,General,Hyderabad,"Hyderabad (Cyber Towers, Hitech City); custom software/web/mobile dev; VERIFIED printed on hsbinfotech.com/contact-us (mailto); MX OK (O365)"
 ,Tech Tree,info@techtree.in,Corporate Office,General,Hyderabad,Hyderabad (Uppal); custom software/web/mobile dev; VERIFIED printed on techtree.in/contact (mailto); MX OK (Hostinger)
+,Pengwin Solutions,hyderabad@pengwinsolutions.com,Hyderabad Branch,General,Hyderabad,Hyderabad (Gachibowli); web/mobile app & custom software dev; VERIFIED printed on pengwinsolutions.com/contact-us (Hyderabad-branch mailto); MX OK (Hostinger)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -69,3 +69,5 @@
 ,AppShark Software,sales@appshark.com,Sales Team,Sales,Hyderabad,Hyderabad; Salesforce/mobile/enterprise app dev; VERIFIED printed on appshark.com/contact-us (mailto); MX OK (Google)
 ,Vikisol Technologies,connect@vikisol.in,Contact Desk,General,Hyderabad,Hyderabad (Mindspace) + Bengaluru; Salesforce/SAP/ServiceNow consulting; VERIFIED printed on vikisol.in/contact (mailto); MX OK (O365)
 ,MicroPyramid,hello@micropyramid.com,Contact Desk,General,Hyderabad,Hyderabad (KPHB); Python/Django/Salesforce & cloud dev; VERIFIED printed on micropyramid.com/contact (mailto); MX OK (Google)
+,Veritis Group,connect@veritis.com,Contact Desk,General,Hyderabad,Hyderabad; DevOps/cloud/IT consulting (US+Hyd); VERIFIED printed on veritis.com/contact (mailto); MX OK (O365)
+,Devathon,hello@devathon.com,Contact Desk,General,Hyderabad,Hyderabad; product design & software dev; VERIFIED printed on devathon.com/contact (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -58,3 +58,5 @@
 ,Ahex Technologies,hr@ahex.co.in,HR Desk,Recruitment,Hyderabad,"Hyderabad; web/mobile/AI software dev; VERIFIED printed on ahex.co/contact for HR (mailto, ahex.co.in domain); MX OK (Yahoo Biz)"
 ,SmartX Solutions,business@smartxsolutions.in,Contact Desk,General,Hyderabad,Hyderabad (New Malakpet); web/app/SaaS dev agency; VERIFIED printed on smartxsolutions.in/contact-us (mailto); MX OK (Zoho)
 ,EasyQuickWeb,info@easyquickweb.com,Corporate Office,General,Hyderabad,Hyderabad; web design/dev & digital agency; VERIFIED printed on easyquickweb.com/contact-us (mailto); MX OK (Hostinger)
+,OzrIT,hr@ozrit.com,HR Desk,Recruitment,Hyderabad,Hyderabad; web/mobile/cloud dev & digital services; VERIFIED printed on ozrit.com/contact-us (mailto); MX OK (Google)
+,Techweblabs,info@techweblabs.com,Corporate Office,General,Hyderabad,"Hyderabad (T-Hub, Gachibowli); web/app/AI dev; VERIFIED printed on techweblabs.com/contact (mailto); MX OK"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -148,3 +148,4 @@
 ,CentoTech Services,info@centotech.com,Corporate Office,General,Hyderabad,"Hyderabad (Gachibowli); web/mobile app & software dev; VERIFIED printed on centotech.in (mailto, centotech.com); MX OK (O365)"
 ,Innvectra,info@innvectra.com,Corporate Office,General,Hyderabad,"Hyderabad (Madhapur, Ayyappa Society); web/mobile/software dev; VERIFIED printed on innvectra.com (mailto); MX OK (O365)"
 ,Team Erudite,accounts@teamerudite.com,Contact Desk,General,Hyderabad,Hyderabad (Kukatpally); web/mobile app & software dev; VERIFIED printed on teamerudite.com/contact-us (mailto); MX OK (Google)
+,Magnaquest Technologies,sales@magnaquest.com,Sales Team,Sales,Hyderabad,Hyderabad (Madhapur); subscription/billing & OTT monetization software product (Sure); VERIFIED printed on magnaquest.com (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -135,3 +135,4 @@
 ,FreJun,hello@frejun.com,Contact Desk,General,Hyderabad,"Hyderabad (CIE@IIIT-H, Gachibowli); virtual-calling/telephony SaaS product; VERIFIED printed on frejun.com/contact-us (mailto); MX OK (O365)"
 ,Kenyt.AI,careers@kenyt.ai,Careers Desk,Recruitment,Hyderabad,"Hyderabad (T-Hub 2.0, Madhapur); conversational-AI chatbot/agent SaaS; VERIFIED printed on kenyt.ai/contact-us (mailto); MX OK (Zoho)"
 ,SignalX.ai,sales@signalx.ai,Sales Team,Sales,Hyderabad,"Hyderabad (T-Hub, Raidurgam); AI-driven third-party risk & due-diligence SaaS; VERIFIED printed on signalx.ai/contact-us (mailto); MX OK (Google)"
+,Param.ai,sales@param.ai,Sales Team,Sales,Hyderabad,Hyderabad (Gachibowli); AI recruitment/talent-intelligence SaaS; VERIFIED printed on param.ai footer (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -115,3 +115,4 @@
 ,Conrep Solutions,sales@conrep.com,Sales Team,Sales,Hyderabad,"Hyderabad office (Jubilee Hills, per directory; also US); PSA/staffing & recruiting software product; VERIFIED printed on conrep.com (mailto); MX OK"
 ,Web Synergies,sales@websynergies.com,Sales Team,Sales,Hyderabad,Hyderabad (Banjara Hills; India arm of Singapore firm); digital transformation/web/cloud dev; VERIFIED printed on websynergies.com/contact-us (mailto); MX OK (O365)
 ,Stratosphere IT Services,info@stratosphere.co.in,Corporate Office,General,Hyderabad,Hyderabad (Madhapur); software dev & IT services; VERIFIED printed on stratosphere.co.in (mailto); MX OK
+,Amigo Creatz,connect@amigocreatz.in,Contact Desk,General,Hyderabad,Hyderabad (Banjara Hills); web/app dev & digital marketing; VERIFIED printed on amigocreatz.in (mailto); MX OK (Hostinger)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -102,3 +102,4 @@
 ,Jeevan Scientific Technology,info@jeevanscientific.com,Corporate Office,General,Hyderabad,Hyderabad (Lanco Hills); clinical research/pharmacovigilance IT & software; VERIFIED printed on jeevanscientific.com (mailto); MX OK (O365)
 ,Marut Drones,enquiries@marutdrones.com,Contact Desk,General,Hyderabad,Hyderabad (Madhapur); drone-tech hardware + software/AI platforms; VERIFIED printed on marutdrones.com/contact-us (mailto); MX OK (Google)
 ,Grene Robotics,workwithus@grenerobotics.com,Careers Desk,Recruitment,Hyderabad,"Hyderabad (Gachibowli, HQ); autonomous systems/AI drone-defense (Indrajaal); VERIFIED printed on grenerobotics.com/contact-us (mailto); MX OK (Google)"
+,IIC Technologies,info@iictechnologies.com,Corporate Office,General,Hyderabad,Hyderabad (HQ); geospatial/hydrographic & GIS software services; VERIFIED printed on iictechnologies.com (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -131,3 +131,4 @@
 ,BizAcuity Solutions,solutions@bizacuity.com,Contact Desk,General,Hyderabad,Hyderabad (Madhapur); BI/data analytics & AI consulting; VERIFIED printed on bizacuity.com/contact-us (mailto); MX OK
 ,Helical IT Solutions,nikhilesh@helicaltech.com,Nikhilesh (contact),General,Hyderabad,Hyderabad (Somajiguda); open-source BI/data warehousing & analytics; VERIFIED published contact mailto on helicaltech.com; MX OK (O365)
 ,Threshold Software Solutions,info@thresholdsoft.com,Corporate Office,General,Hyderabad,Hyderabad (Jubilee Hills); software dev & IT services; VERIFIED printed on thresholdsoft.com (mailto); MX OK (Google)
+,Runo,care@runo.ai,Contact Desk,General,Hyderabad,"Hyderabad (Cyber Towers, HITEC City); call-management/CRM SaaS product; VERIFIED printed on runo.ai/contact (mailto); MX OK (Google)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -60,3 +60,4 @@
 ,EasyQuickWeb,info@easyquickweb.com,Corporate Office,General,Hyderabad,Hyderabad; web design/dev & digital agency; VERIFIED printed on easyquickweb.com/contact-us (mailto); MX OK (Hostinger)
 ,OzrIT,hr@ozrit.com,HR Desk,Recruitment,Hyderabad,Hyderabad; web/mobile/cloud dev & digital services; VERIFIED printed on ozrit.com/contact-us (mailto); MX OK (Google)
 ,Techweblabs,info@techweblabs.com,Corporate Office,General,Hyderabad,"Hyderabad (T-Hub, Gachibowli); web/app/AI dev; VERIFIED printed on techweblabs.com/contact (mailto); MX OK"
+,Codetru,queries@codetru.com,Contact Desk,General,Hyderabad,Hyderabad; software/web/mobile & AI dev; VERIFIED printed on codetru.com (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -116,3 +116,4 @@
 ,Web Synergies,sales@websynergies.com,Sales Team,Sales,Hyderabad,Hyderabad (Banjara Hills; India arm of Singapore firm); digital transformation/web/cloud dev; VERIFIED printed on websynergies.com/contact-us (mailto); MX OK (O365)
 ,Stratosphere IT Services,info@stratosphere.co.in,Corporate Office,General,Hyderabad,Hyderabad (Madhapur); software dev & IT services; VERIFIED printed on stratosphere.co.in (mailto); MX OK
 ,Amigo Creatz,connect@amigocreatz.in,Contact Desk,General,Hyderabad,Hyderabad (Banjara Hills); web/app dev & digital marketing; VERIFIED printed on amigocreatz.in (mailto); MX OK (Hostinger)
+,Seven Web Tech,info@sevenwebtech.com,Corporate Office,General,Hyderabad,Hyderabad (Hyderguda); web/app/ecommerce dev; VERIFIED printed on sevenwebtech.com (mailto); MX OK (Hostinger)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -85,3 +85,4 @@
 ,Gleecus TechLabs,hello@gleecus.com,Contact Desk,General,Hyderabad,"Hyderabad; digital/product engineering, AI & cloud; VERIFIED printed on gleecus.com/contact-us (mailto); MX OK (O365)"
 ,Tek Leaders,info@tekleaders.com,Corporate Office,General,Hyderabad,Hyderabad; IT services/data & cloud; VERIFIED info@ mailto on tekleaders.com; MX OK (O365)
 ,Waytowebs,info@waytowebs.com,Corporate Office,General,Hyderabad,Hyderabad; web/app/UI-UX design & development; VERIFIED printed on waytowebs.com (mailto); MX OK (Google)
+,CreditMitra,support@creditmitra.in,Contact Desk,General,Hyderabad,"Hyderabad (HQ); lending/insurance fintech; VERIFIED printed on creditmitra.in/contact-us (mailto), support alias; MX OK (Google)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -61,3 +61,5 @@
 ,OzrIT,hr@ozrit.com,HR Desk,Recruitment,Hyderabad,Hyderabad; web/mobile/cloud dev & digital services; VERIFIED printed on ozrit.com/contact-us (mailto); MX OK (Google)
 ,Techweblabs,info@techweblabs.com,Corporate Office,General,Hyderabad,"Hyderabad (T-Hub, Gachibowli); web/app/AI dev; VERIFIED printed on techweblabs.com/contact (mailto); MX OK"
 ,Codetru,queries@codetru.com,Contact Desk,General,Hyderabad,Hyderabad; software/web/mobile & AI dev; VERIFIED printed on codetru.com (mailto); MX OK (O365)
+,Tech Cloud ERP,sales@techclouderp.com,Sales Team,Sales,Hyderabad,"Hyderabad (Madhapur, Kavuri Hills); cloud ERP software product; VERIFIED printed on techclouderp.com/contact-us (mailto); MX OK (Google)"
+,SYOFT,info@syoft.com,Corporate Office,General,Hyderabad,Hyderabad; mobile app/web/low-code dev; VERIFIED printed on syoft.com (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -147,3 +147,4 @@
 ,Vaakruthi Software Solutions,info@vaakruthi.co.in,Corporate Office,General,Hyderabad,"Hyderabad (Ameerpet, Aditya Trade Center); web/mobile/software dev & staffing; VERIFIED printed on vaakruthi.com (mailto, vaakruthi.co.in); MX OK (O365)"
 ,CentoTech Services,info@centotech.com,Corporate Office,General,Hyderabad,"Hyderabad (Gachibowli); web/mobile app & software dev; VERIFIED printed on centotech.in (mailto, centotech.com); MX OK (O365)"
 ,Innvectra,info@innvectra.com,Corporate Office,General,Hyderabad,"Hyderabad (Madhapur, Ayyappa Society); web/mobile/software dev; VERIFIED printed on innvectra.com (mailto); MX OK (O365)"
+,Team Erudite,accounts@teamerudite.com,Contact Desk,General,Hyderabad,Hyderabad (Kukatpally); web/mobile app & software dev; VERIFIED printed on teamerudite.com/contact-us (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -129,3 +129,4 @@
 ,BeyondScale Technologies,hello@beyondscale.tech,Contact Desk,General,Hyderabad,"Hyderabad (office; US HQ Jupiter FL); AWS partner, cloud/DevOps & AI product engineering; VERIFIED printed on beyondscale.tech (mailto); MX OK (O365)"
 ,DataTerminal,contact@dataterminal.co,Contact Desk,General,Hyderabad,Hyderabad (Financial District); AI/data-engineering services & products; VERIFIED printed on dataterminal.co/contact (mailto); MX OK (O365)
 ,BizAcuity Solutions,solutions@bizacuity.com,Contact Desk,General,Hyderabad,Hyderabad (Madhapur); BI/data analytics & AI consulting; VERIFIED printed on bizacuity.com/contact-us (mailto); MX OK
+,Helical IT Solutions,nikhilesh@helicaltech.com,Nikhilesh (contact),General,Hyderabad,Hyderabad (Somajiguda); open-source BI/data warehousing & analytics; VERIFIED published contact mailto on helicaltech.com; MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -137,3 +137,4 @@
 ,SignalX.ai,sales@signalx.ai,Sales Team,Sales,Hyderabad,"Hyderabad (T-Hub, Raidurgam); AI-driven third-party risk & due-diligence SaaS; VERIFIED printed on signalx.ai/contact-us (mailto); MX OK (Google)"
 ,Param.ai,sales@param.ai,Sales Team,Sales,Hyderabad,Hyderabad (Gachibowli); AI recruitment/talent-intelligence SaaS; VERIFIED printed on param.ai footer (mailto); MX OK (Google)
 ,ekincare,careers@ekincare.com,Careers Desk,Recruitment,Hyderabad,Hyderabad (HQ - engineering/clinical ops); corporate health-benefits SaaS platform; VERIFIED printed on ekincare.com (mailto); MX OK (O365)
+,APPIT Software Solutions,info@appitsoftware.com,Corporate Office,General,Hyderabad,"Hyderabad (HQ, Gachibowli); fleet/logistics ERP & custom software products; VERIFIED printed on appitsoftware.com (mailto); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -146,3 +146,4 @@
 ,Haystek Technologies,hr@haystek.com,HR Desk,Recruitment,Hyderabad,Hyderabad (Madhapur); web/mobile app & software dev; VERIFIED printed on haystek.com (mailto); MX OK (Google)
 ,Vaakruthi Software Solutions,info@vaakruthi.co.in,Corporate Office,General,Hyderabad,"Hyderabad (Ameerpet, Aditya Trade Center); web/mobile/software dev & staffing; VERIFIED printed on vaakruthi.com (mailto, vaakruthi.co.in); MX OK (O365)"
 ,CentoTech Services,info@centotech.com,Corporate Office,General,Hyderabad,"Hyderabad (Gachibowli); web/mobile app & software dev; VERIFIED printed on centotech.in (mailto, centotech.com); MX OK (O365)"
+,Innvectra,info@innvectra.com,Corporate Office,General,Hyderabad,"Hyderabad (Madhapur, Ayyappa Society); web/mobile/software dev; VERIFIED printed on innvectra.com (mailto); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -106,3 +106,4 @@
 ,Knack Systems,careers@knacksystems.com,Careers Desk,Recruitment,Hyderabad,Hyderabad (Kukatpally); SAP CX/enterprise consulting & implementation; VERIFIED printed on knacksystems.com/contact-us (mailto); MX OK (Google)
 ,Versatile Mobitech,hr@versatilemobitech.com,HR Desk,Recruitment,Hyderabad,Hyderabad (Kondapur); web/mobile app & ecommerce dev; VERIFIED printed on versatilemobitech.com/contact-us (mailto); MX OK (Google)
 ,KBK Business Solutions,info@kbkbusinesssolutions.com,Corporate Office,General,Hyderabad,Hyderabad; web development & digital marketing agency; VERIFIED printed on kbkbusinesssolutions.com (mailto); MX OK (one.com)
+,Origin Softwares,info@originsoftwares.com,Corporate Office,General,Hyderabad,Hyderabad (Masab Tank); custom software/web/mobile dev & training; VERIFIED printed on originsoftwares.com (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -136,3 +136,4 @@
 ,Kenyt.AI,careers@kenyt.ai,Careers Desk,Recruitment,Hyderabad,"Hyderabad (T-Hub 2.0, Madhapur); conversational-AI chatbot/agent SaaS; VERIFIED printed on kenyt.ai/contact-us (mailto); MX OK (Zoho)"
 ,SignalX.ai,sales@signalx.ai,Sales Team,Sales,Hyderabad,"Hyderabad (T-Hub, Raidurgam); AI-driven third-party risk & due-diligence SaaS; VERIFIED printed on signalx.ai/contact-us (mailto); MX OK (Google)"
 ,Param.ai,sales@param.ai,Sales Team,Sales,Hyderabad,Hyderabad (Gachibowli); AI recruitment/talent-intelligence SaaS; VERIFIED printed on param.ai footer (mailto); MX OK (Google)
+,ekincare,careers@ekincare.com,Careers Desk,Recruitment,Hyderabad,Hyderabad (HQ - engineering/clinical ops); corporate health-benefits SaaS platform; VERIFIED printed on ekincare.com (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -77,3 +77,4 @@
 ,Innoit Labs,info@innoitlabs.com,Corporate Office,General,Hyderabad,Hyderabad; web/mobile/cloud software dev; VERIFIED printed on innoitlabs.com (mailto); MX OK (Google)
 ,Analogue IT Solutions,info@analogueitsolutions.com,Corporate Office,General,Hyderabad,Hyderabad; web/app/software dev; VERIFIED printed on analogueitsolutions.com/contact-us (mailto); MX OK
 ,Conquerors Tech,hr@conquerorstech.net,HR Desk,Recruitment,Hyderabad,Hyderabad; custom software/web/mobile dev; VERIFIED printed on conquerorstech.net/contact-us (mailto); MX OK (Google)
+,iMatrix Solutions,info@imatrixsolutions.com,Corporate Office,General,Hyderabad,Hyderabad (Dilsukhnagar); web design/dev & SEO; VERIFIED printed on imatrixsolutions.com/contact-us (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -108,3 +108,4 @@
 ,KBK Business Solutions,info@kbkbusinesssolutions.com,Corporate Office,General,Hyderabad,Hyderabad; web development & digital marketing agency; VERIFIED printed on kbkbusinesssolutions.com (mailto); MX OK (one.com)
 ,Origin Softwares,info@originsoftwares.com,Corporate Office,General,Hyderabad,Hyderabad (Masab Tank); custom software/web/mobile dev & training; VERIFIED printed on originsoftwares.com (mailto); MX OK (Google)
 ,Charter Global,sales@charterglobal.com,Sales Team,Sales,Hyderabad,Hyderabad delivery center (Madhapur; US HQ Atlanta); IT services/data/AI/ServiceNow; VERIFIED printed on charterglobal.com/contact-us (mailto); MX OK (O365)
+,AiFA Labs,info@aifalabs.com,Corporate Office,General,Hyderabad,Hyderabad (Kondapur); enterprise AI/GenAI platforms & IT services; VERIFIED printed on aifalabs.com (mailto); MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -130,3 +130,4 @@
 ,DataTerminal,contact@dataterminal.co,Contact Desk,General,Hyderabad,Hyderabad (Financial District); AI/data-engineering services & products; VERIFIED printed on dataterminal.co/contact (mailto); MX OK (O365)
 ,BizAcuity Solutions,solutions@bizacuity.com,Contact Desk,General,Hyderabad,Hyderabad (Madhapur); BI/data analytics & AI consulting; VERIFIED printed on bizacuity.com/contact-us (mailto); MX OK
 ,Helical IT Solutions,nikhilesh@helicaltech.com,Nikhilesh (contact),General,Hyderabad,Hyderabad (Somajiguda); open-source BI/data warehousing & analytics; VERIFIED published contact mailto on helicaltech.com; MX OK (O365)
+,Threshold Software Solutions,info@thresholdsoft.com,Corporate Office,General,Hyderabad,Hyderabad (Jubilee Hills); software dev & IT services; VERIFIED printed on thresholdsoft.com (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -134,3 +134,4 @@
 ,Runo,care@runo.ai,Contact Desk,General,Hyderabad,"Hyderabad (Cyber Towers, HITEC City); call-management/CRM SaaS product; VERIFIED printed on runo.ai/contact (mailto); MX OK (Google)"
 ,FreJun,hello@frejun.com,Contact Desk,General,Hyderabad,"Hyderabad (CIE@IIIT-H, Gachibowli); virtual-calling/telephony SaaS product; VERIFIED printed on frejun.com/contact-us (mailto); MX OK (O365)"
 ,Kenyt.AI,careers@kenyt.ai,Careers Desk,Recruitment,Hyderabad,"Hyderabad (T-Hub 2.0, Madhapur); conversational-AI chatbot/agent SaaS; VERIFIED printed on kenyt.ai/contact-us (mailto); MX OK (Zoho)"
+,SignalX.ai,sales@signalx.ai,Sales Team,Sales,Hyderabad,"Hyderabad (T-Hub, Raidurgam); AI-driven third-party risk & due-diligence SaaS; VERIFIED printed on signalx.ai/contact-us (mailto); MX OK (Google)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -43,3 +43,4 @@
 ,mroads,reachout@mroads.com,Contact Desk,General,Hyderabad,Hyderabad; recruiting-tech (Panna AI) + software services; VERIFIED printed on mroads.com/contact (mailto); MX OK (Google)
 ,Tvarana,info@tvarana.com,Corporate Office,General,Hyderabad,Hyderabad; software/ServiceNow/data dev; VERIFIED printed on tvarana.com/contact-us (mailto); MX OK (O365)
 ,Nvish Solutions,sales@nvish.com,Sales Team,Sales,Hyderabad,Hyderabad; IT services/analytics/automation; VERIFIED printed on nvish.com/contact-us (mailto); MX OK (O365)
+,CtrlS Datacenters,marketing@ctrls.in,Marketing Desk,Marketing,Hyderabad,Hyderabad HQ; data centers/managed cloud; VERIFIED printed on ctrls.com/contact-us (mailto); MX OK (Cisco)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -92,3 +92,4 @@
 ,SlashMonk,info@slashmonk.com,Corporate Office,General,Hyderabad,Hyderabad; product/web engineering; VERIFIED printed on slashmonk.com/contact (mailto); MX OK
 ,DigitalOps,hello@digitalops.in,Corporate Office,General,Hyderabad,Hyderabad; web/app dev & digital solutions; VERIFIED printed on digitalops.in/contact-us (mailto); MX OK (Hostinger)
 ,Quixy (VividMinds Technologies),careers@quixy.com,Careers Desk,Recruitment,Hyderabad,"Hyderabad (Nanakramguda, Financial District); no-code/low-code app development SaaS platform; VERIFIED printed on quixy.com/contact (mailto); MX OK (O365)"
+,Landeed (John Salt Pvt Ltd),customers@landeed.com,Contact Desk,General,Hyderabad,"Hyderabad (HITEC City); property-records/title-search SaaS (YC); VERIFIED printed on landeed.com/contact-us (mailto), support alias; MX OK (Google)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -133,3 +133,4 @@
 ,Threshold Software Solutions,info@thresholdsoft.com,Corporate Office,General,Hyderabad,Hyderabad (Jubilee Hills); software dev & IT services; VERIFIED printed on thresholdsoft.com (mailto); MX OK (Google)
 ,Runo,care@runo.ai,Contact Desk,General,Hyderabad,"Hyderabad (Cyber Towers, HITEC City); call-management/CRM SaaS product; VERIFIED printed on runo.ai/contact (mailto); MX OK (Google)"
 ,FreJun,hello@frejun.com,Contact Desk,General,Hyderabad,"Hyderabad (CIE@IIIT-H, Gachibowli); virtual-calling/telephony SaaS product; VERIFIED printed on frejun.com/contact-us (mailto); MX OK (O365)"
+,Kenyt.AI,careers@kenyt.ai,Careers Desk,Recruitment,Hyderabad,"Hyderabad (T-Hub 2.0, Madhapur); conversational-AI chatbot/agent SaaS; VERIFIED printed on kenyt.ai/contact-us (mailto); MX OK (Zoho)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -44,3 +44,6 @@
 ,Tvarana,info@tvarana.com,Corporate Office,General,Hyderabad,Hyderabad; software/ServiceNow/data dev; VERIFIED printed on tvarana.com/contact-us (mailto); MX OK (O365)
 ,Nvish Solutions,sales@nvish.com,Sales Team,Sales,Hyderabad,Hyderabad; IT services/analytics/automation; VERIFIED printed on nvish.com/contact-us (mailto); MX OK (O365)
 ,CtrlS Datacenters,marketing@ctrls.in,Marketing Desk,Marketing,Hyderabad,Hyderabad HQ; data centers/managed cloud; VERIFIED printed on ctrls.com/contact-us (mailto); MX OK (Cisco)
+,Prowess Software Services,connect@prowesssoft.com,Contact Desk,General,Hyderabad,Hyderabad HQ; software product engineering/QA; VERIFIED printed on prowesssoft.com/contact-us (mailto); MX OK (O365)
+,Bourntec Solutions,info@bourntec.com,HR / Recruitment Desk,Recruitment,Hyderabad,Hyderabad+Chicago; cloud/data/digital services; VERIFIED printed on bourntec.com/contact-us for Sales/Recruitment/HR (mailto); MX OK (O365)
+,Riktam Technologies,ct@riktamtech.com,Contact Desk,General,Hyderabad,"Hyderabad; software/mobile product dev; VERIFIED printed on riktam.com/contact (mailto, riktamtech.com domain); MX OK (Google)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -149,3 +149,4 @@
 ,Innvectra,info@innvectra.com,Corporate Office,General,Hyderabad,"Hyderabad (Madhapur, Ayyappa Society); web/mobile/software dev; VERIFIED printed on innvectra.com (mailto); MX OK (O365)"
 ,Team Erudite,accounts@teamerudite.com,Contact Desk,General,Hyderabad,Hyderabad (Kukatpally); web/mobile app & software dev; VERIFIED printed on teamerudite.com/contact-us (mailto); MX OK (Google)
 ,Magnaquest Technologies,sales@magnaquest.com,Sales Team,Sales,Hyderabad,Hyderabad (Madhapur); subscription/billing & OTT monetization software product (Sure); VERIFIED printed on magnaquest.com (mailto); MX OK (O365)
+,Helical IT Solutions,nitin@helicaltech.com,Nitin Sagar,Co-Founder / Director,Hyderabad,Hyderabad (Somajiguda); named-person contact published as mailto on helicaltech.com; MX OK (O365)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -117,3 +117,4 @@
 ,Stratosphere IT Services,info@stratosphere.co.in,Corporate Office,General,Hyderabad,Hyderabad (Madhapur); software dev & IT services; VERIFIED printed on stratosphere.co.in (mailto); MX OK
 ,Amigo Creatz,connect@amigocreatz.in,Contact Desk,General,Hyderabad,Hyderabad (Banjara Hills); web/app dev & digital marketing; VERIFIED printed on amigocreatz.in (mailto); MX OK (Hostinger)
 ,Seven Web Tech,info@sevenwebtech.com,Corporate Office,General,Hyderabad,Hyderabad (Hyderguda); web/app/ecommerce dev; VERIFIED printed on sevenwebtech.com (mailto); MX OK (Hostinger)
+,HSB Infotech,info@hsbinfotech.com,Corporate Office,General,Hyderabad,"Hyderabad (Cyber Towers, Hitech City); custom software/web/mobile dev; VERIFIED printed on hsbinfotech.com/contact-us (mailto); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -78,3 +78,4 @@
 ,Analogue IT Solutions,info@analogueitsolutions.com,Corporate Office,General,Hyderabad,Hyderabad; web/app/software dev; VERIFIED printed on analogueitsolutions.com/contact-us (mailto); MX OK
 ,Conquerors Tech,hr@conquerorstech.net,HR Desk,Recruitment,Hyderabad,Hyderabad; custom software/web/mobile dev; VERIFIED printed on conquerorstech.net/contact-us (mailto); MX OK (Google)
 ,iMatrix Solutions,info@imatrixsolutions.com,Corporate Office,General,Hyderabad,Hyderabad (Dilsukhnagar); web design/dev & SEO; VERIFIED printed on imatrixsolutions.com/contact-us (mailto); MX OK (Google)
+,Trysol Global Services,info@trysol.com,Corporate Office,General,Hyderabad,"Hyderabad (Gachibowli); app/web dev, cloud & IT consulting; VERIFIED printed on trysol.com (mailto); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -154,3 +154,4 @@
 ,ASTROC AS Technology,info@astrocastech.in,Corporate Office,General,Hyderabad,Hyderabad (Uppal Industrial Park); autonomous drones/UGVs & AI autonomy deep-tech; VERIFIED printed on astrocastech.in (mailto); MX OK (Google)
 ,NaPanta,support@napanta.com,Contact Desk,General,Hyderabad,Hyderabad (Somajiguda); agri-advisory/farm management SaaS app; VERIFIED printed on napanta.com (mailto); MX OK (Zoho)
 ,Thanos Technologies,contact@thanos.in,Contact Desk,General,Hyderabad,Hyderabad (per StartupHyderabad dir); agri-drone & precision-ag tech; VERIFIED printed on thanos.in (mailto); MX OK (Google)
+,Tutorials Point,media@tutorialspoint.com,Contact Desk,General,Hyderabad,"Hyderabad (Kavuri Hills, Madhapur); ed-content/e-learning platform; VERIFIED printed on tutorialspoint.com/about/contact_us (mailto); MX OK (Google)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -74,3 +74,5 @@
 ,Rapid Circuitry,contact@rapidcircuitry.com,Contact Desk,General,Hyderabad,Hyderabad (Gachibowli); PCB design/embedded firmware/IoT product dev; VERIFIED printed on rapidcircuitry.com/contact (mailto); MX OK (O365)
 ,MosChip Technologies,contact@moschip.com,Contact Desk,General,Hyderabad,Hyderabad (HQ); semiconductor/VLSI/embedded & IoT design; VERIFIED printed on moschip.com/contact-us (mailto); MX OK (O365)
 ,VALSOC Semiconductor,hr@valsocsemi.com,HR Desk,Recruitment,Hyderabad,Hyderabad; VLSI/semiconductor product & design services; VERIFIED printed on valsocsemi.com/contact-us (mailto); MX OK (Google)
+,Innoit Labs,info@innoitlabs.com,Corporate Office,General,Hyderabad,Hyderabad; web/mobile/cloud software dev; VERIFIED printed on innoitlabs.com (mailto); MX OK (Google)
+,Analogue IT Solutions,info@analogueitsolutions.com,Corporate Office,General,Hyderabad,Hyderabad; web/app/software dev; VERIFIED printed on analogueitsolutions.com/contact-us (mailto); MX OK

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -55,3 +55,5 @@
 ,Pyramid SoftSol,careers@pyramidinc.com,Careers Desk,Recruitment,Hyderabad,"Hyderabad (Madhapur, Hi-Tech City); enterprise software/QA/cloud; VERIFIED printed on pyramidinc.com/india/openings (mailto); MX OK (O365)"
 ,Honey Soft Solutions,info@honeysoftsolutions.in,Corporate Office,General,Hyderabad,Hyderabad (Dilsukhnagar); web/software dev; VERIFIED printed on honeysoftsolutions.in (mailto); MX OK (Google)
 ,Autorox,stayhappy@autorox.co,Contact Desk,General,Hyderabad,"Hyderabad (Gachibowli); AI garage/auto workshop management SaaS; VERIFIED printed on autorox.ai footer (mailto, autorox.co domain); MX OK (Google)"
+,Ahex Technologies,hr@ahex.co.in,HR Desk,Recruitment,Hyderabad,"Hyderabad; web/mobile/AI software dev; VERIFIED printed on ahex.co/contact for HR (mailto, ahex.co.in domain); MX OK (Yahoo Biz)"
+,SmartX Solutions,business@smartxsolutions.in,Contact Desk,General,Hyderabad,Hyderabad (New Malakpet); web/app/SaaS dev agency; VERIFIED printed on smartxsolutions.in/contact-us (mailto); MX OK (Zoho)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -47,3 +47,6 @@
 ,Prowess Software Services,connect@prowesssoft.com,Contact Desk,General,Hyderabad,Hyderabad HQ; software product engineering/QA; VERIFIED printed on prowesssoft.com/contact-us (mailto); MX OK (O365)
 ,Bourntec Solutions,info@bourntec.com,HR / Recruitment Desk,Recruitment,Hyderabad,Hyderabad+Chicago; cloud/data/digital services; VERIFIED printed on bourntec.com/contact-us for Sales/Recruitment/HR (mailto); MX OK (O365)
 ,Riktam Technologies,ct@riktamtech.com,Contact Desk,General,Hyderabad,"Hyderabad; software/mobile product dev; VERIFIED printed on riktam.com/contact (mailto, riktamtech.com domain); MX OK (Google)"
+,InfoVision,info@infovision.com,Corporate Office,General,Hyderabad,Hyderabad+Dallas; digital/cloud/data IT services; VERIFIED printed on infovision.com/contact-us (mailto); MX OK (Barracuda)
+,Tech Vedika,info@techvedika.com,Corporate Office,General,Hyderabad,Hyderabad HQ; AI/cloud/product engineering; VERIFIED printed on techvedika.com/contact (mailto); MX OK (O365)
+,Miracle Software Systems,info@miraclesoft.com,Corporate Office,General,Hyderabad,Novi HQ + large Hyderabad delivery center; integration/cloud/digital; VERIFIED printed on miraclesoft.com/contact-us (mailto); MX OK

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -122,3 +122,4 @@
 ,Pengwin Solutions,hyderabad@pengwinsolutions.com,Hyderabad Branch,General,Hyderabad,Hyderabad (Gachibowli); web/mobile app & custom software dev; VERIFIED printed on pengwinsolutions.com/contact-us (Hyderabad-branch mailto); MX OK (Hostinger)
 ,500apps,support@500apps.com,Contact Desk,General,Hyderabad,Hyderabad (Madhapur; +Dubai); all-in-one business SaaS suite (Aumtech); VERIFIED printed on 500apps.com/contact-us (mailto); MX OK (Google)
 ,Geekschip,info@geekschip.com,Corporate Office,General,Hyderabad,"Hyderabad (Kavuri Hills, Madhapur); digital marketing & web/app dev; VERIFIED printed on geekschip.com/contact-us (mailto); MX OK (O365)"
+,Pride Web Technologies,support@pridewebtech.com,Contact Desk,General,Hyderabad,Hyderabad (Domalguda); web/app dev & digital marketing; VERIFIED printed on pridewebtech.com/contact-us (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -88,3 +88,5 @@
 ,CreditMitra,support@creditmitra.in,Contact Desk,General,Hyderabad,"Hyderabad (HQ); lending/insurance fintech; VERIFIED printed on creditmitra.in/contact-us (mailto), support alias; MX OK (Google)"
 ,Digital Eyecon,info@digitaleyecon.com,Corporate Office,General,Hyderabad,Hyderabad; web/mobile app dev & digital marketing; VERIFIED printed on digitaleyecon.com/contact-us (mailto); MX OK (Zoho)
 ,ThreeAtoms,contact@threeatoms.com,Contact Desk,General,Hyderabad,Hyderabad (Kukatpally); web/app software dev; VERIFIED printed on threeatoms.com (mailto); MX OK (Zoho)
+,Toyaja,sales@toyaja.com,Sales Team,Sales,Hyderabad,Hyderabad; web/mobile/enterprise software dev; VERIFIED printed on toyaja.com/contact-us (mailto); MX OK (Google)
+,SlashMonk,info@slashmonk.com,Corporate Office,General,Hyderabad,Hyderabad; product/web engineering; VERIFIED printed on slashmonk.com/contact (mailto); MX OK

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -84,3 +84,4 @@
 ,DataSpeaks,hello@dataspeaks.co,Contact Desk,General,Hyderabad,Hyderabad; data engineering/analytics/AI services; VERIFIED printed on dataspeaks.co/contact (mailto); MX OK (O365)
 ,Gleecus TechLabs,hello@gleecus.com,Contact Desk,General,Hyderabad,"Hyderabad; digital/product engineering, AI & cloud; VERIFIED printed on gleecus.com/contact-us (mailto); MX OK (O365)"
 ,Tek Leaders,info@tekleaders.com,Corporate Office,General,Hyderabad,Hyderabad; IT services/data & cloud; VERIFIED info@ mailto on tekleaders.com; MX OK (O365)
+,Waytowebs,info@waytowebs.com,Corporate Office,General,Hyderabad,Hyderabad; web/app/UI-UX design & development; VERIFIED printed on waytowebs.com (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -101,3 +101,4 @@
 ,WebNapp Studio,sales@webnappstudio.in,Sales Team,Sales,Hyderabad,Hyderabad (Kondapur); Shopify/web & app development; VERIFIED printed on hyderabad.webnappstudio.in (mailto); MX OK (StackMail)
 ,Jeevan Scientific Technology,info@jeevanscientific.com,Corporate Office,General,Hyderabad,Hyderabad (Lanco Hills); clinical research/pharmacovigilance IT & software; VERIFIED printed on jeevanscientific.com (mailto); MX OK (O365)
 ,Marut Drones,enquiries@marutdrones.com,Contact Desk,General,Hyderabad,Hyderabad (Madhapur); drone-tech hardware + software/AI platforms; VERIFIED printed on marutdrones.com/contact-us (mailto); MX OK (Google)
+,Grene Robotics,workwithus@grenerobotics.com,Careers Desk,Recruitment,Hyderabad,"Hyderabad (Gachibowli, HQ); autonomous systems/AI drone-defense (Indrajaal); VERIFIED printed on grenerobotics.com/contact-us (mailto); MX OK (Google)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -90,3 +90,4 @@
 ,ThreeAtoms,contact@threeatoms.com,Contact Desk,General,Hyderabad,Hyderabad (Kukatpally); web/app software dev; VERIFIED printed on threeatoms.com (mailto); MX OK (Zoho)
 ,Toyaja,sales@toyaja.com,Sales Team,Sales,Hyderabad,Hyderabad; web/mobile/enterprise software dev; VERIFIED printed on toyaja.com/contact-us (mailto); MX OK (Google)
 ,SlashMonk,info@slashmonk.com,Corporate Office,General,Hyderabad,Hyderabad; product/web engineering; VERIFIED printed on slashmonk.com/contact (mailto); MX OK
+,DigitalOps,hello@digitalops.in,Corporate Office,General,Hyderabad,Hyderabad; web/app dev & digital solutions; VERIFIED printed on digitalops.in/contact-us (mailto); MX OK (Hostinger)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -64,3 +64,5 @@
 ,Tech Cloud ERP,sales@techclouderp.com,Sales Team,Sales,Hyderabad,"Hyderabad (Madhapur, Kavuri Hills); cloud ERP software product; VERIFIED printed on techclouderp.com/contact-us (mailto); MX OK (Google)"
 ,SYOFT,info@syoft.com,Corporate Office,General,Hyderabad,Hyderabad; mobile app/web/low-code dev; VERIFIED printed on syoft.com (mailto); MX OK (Google)
 ,USM Business Systems,sales@usmsystems.com,Sales Team,Sales,Hyderabad,"Hyderabad delivery center (US HQ, Virginia); IT staffing/software/AI; VERIFIED printed on usmsystems.com/contact-us (mailto); MX OK (O365)"
+,Ogre Head Studio,support@ogrehead.com,Contact Desk,General,Hyderabad,"Hyderabad; indie video game studio (Asura); VERIFIED printed on ogreheadstudio.com footer (mailto, ogrehead.com domain); MX OK"
+,GameNexa Studios,info@gamenexa.com,Corporate Office,General,Hyderabad,Hyderabad (HQ); mobile app/game dev & digital marketing; VERIFIED printed on gamenexa.com (mailto); MX OK

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -95,3 +95,4 @@
 ,Landeed (John Salt Pvt Ltd),customers@landeed.com,Contact Desk,General,Hyderabad,"Hyderabad (HITEC City); property-records/title-search SaaS (YC); VERIFIED printed on landeed.com/contact-us (mailto), support alias; MX OK (Google)"
 ,Agasthya App Labs,info@agasthyaapplabs.com,Corporate Office,General,Hyderabad,Hyderabad (one of its offices; also Bengaluru); mobile/web app development; VERIFIED printed on agasthyaapplabs.com (mailto); MX OK (O365)
 ,myMoneyKarma,askus@mymoneykarma.com,Contact Desk,General,Hyderabad,"Hyderabad (T-Hub); personal-finance/credit fintech; VERIFIED printed on moneykarma.com (mailto), support alias; MX OK (Google)"
+,CitiusTech,info@citiustech.com,Corporate Office,General,Hyderabad,"Hyderabad (HITEC City, Madhapur) delivery center; healthcare IT/consulting & engineering; VERIFIED printed on citiustech.com/contact-us (mailto); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -143,3 +143,4 @@
 ,Modak Analytics,sales@modak.com,Sales Team,Sales,Hyderabad,"Hyderabad (Nanakramguda, Financial District delivery center); data engineering/management platform; VERIFIED printed on modak.com/contact-us (mailto); MX OK (O365)"
 ,Algoleap Technologies,contact@algoleap.com,Contact Desk,General,Hyderabad,"Hyderabad (Cyber Gateway, HITEC City); digital/data/AI engineering services; VERIFIED printed on algoleap.com (mailto); MX OK (O365)"
 ,Keansa Solutions,info@keansa.com,Corporate Office,General,Hyderabad,"Hyderabad (HITEC City, Manjeera Trinity); data quality/analytics & IT services; VERIFIED printed on keansa.com/contact-us (mailto); MX OK (O365)"
+,Haystek Technologies,hr@haystek.com,HR Desk,Recruitment,Hyderabad,Hyderabad (Madhapur); web/mobile app & software dev; VERIFIED printed on haystek.com (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -142,3 +142,4 @@
 ,Apxor,contact@apxor.com,Contact Desk,General,Hyderabad,Hyderabad (Kondapur); mobile product-analytics & nudging SaaS; VERIFIED printed on apxor.com/contact-us (mailto); MX OK (Google)
 ,Modak Analytics,sales@modak.com,Sales Team,Sales,Hyderabad,"Hyderabad (Nanakramguda, Financial District delivery center); data engineering/management platform; VERIFIED printed on modak.com/contact-us (mailto); MX OK (O365)"
 ,Algoleap Technologies,contact@algoleap.com,Contact Desk,General,Hyderabad,"Hyderabad (Cyber Gateway, HITEC City); digital/data/AI engineering services; VERIFIED printed on algoleap.com (mailto); MX OK (O365)"
+,Keansa Solutions,info@keansa.com,Corporate Office,General,Hyderabad,"Hyderabad (HITEC City, Manjeera Trinity); data quality/analytics & IT services; VERIFIED printed on keansa.com/contact-us (mailto); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -73,3 +73,4 @@
 ,Devathon,hello@devathon.com,Contact Desk,General,Hyderabad,Hyderabad; product design & software dev; VERIFIED printed on devathon.com/contact (mailto); MX OK (Google)
 ,Rapid Circuitry,contact@rapidcircuitry.com,Contact Desk,General,Hyderabad,Hyderabad (Gachibowli); PCB design/embedded firmware/IoT product dev; VERIFIED printed on rapidcircuitry.com/contact (mailto); MX OK (O365)
 ,MosChip Technologies,contact@moschip.com,Contact Desk,General,Hyderabad,Hyderabad (HQ); semiconductor/VLSI/embedded & IoT design; VERIFIED printed on moschip.com/contact-us (mailto); MX OK (O365)
+,VALSOC Semiconductor,hr@valsocsemi.com,HR Desk,Recruitment,Hyderabad,Hyderabad; VLSI/semiconductor product & design services; VERIFIED printed on valsocsemi.com/contact-us (mailto); MX OK (Google)

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -96,3 +96,4 @@
 ,Agasthya App Labs,info@agasthyaapplabs.com,Corporate Office,General,Hyderabad,Hyderabad (one of its offices; also Bengaluru); mobile/web app development; VERIFIED printed on agasthyaapplabs.com (mailto); MX OK (O365)
 ,myMoneyKarma,askus@mymoneykarma.com,Contact Desk,General,Hyderabad,"Hyderabad (T-Hub); personal-finance/credit fintech; VERIFIED printed on moneykarma.com (mailto), support alias; MX OK (Google)"
 ,CitiusTech,info@citiustech.com,Corporate Office,General,Hyderabad,"Hyderabad (HITEC City, Madhapur) delivery center; healthcare IT/consulting & engineering; VERIFIED printed on citiustech.com/contact-us (mailto); MX OK (O365)"
+,ValueMomentum,ContactNJ@valuemomentum.com,Contact Desk,General,Hyderabad,"Hyderabad (Gachibowli, ValueMomentum Towers) major dev center; insurance/BFSI software & engineering; VERIFIED printed on valuemomentum.com/contact (mailto, US contact desk alias); MX OK (O365)"

--- a/industry/city/city_hyderabad_01.csv
+++ b/industry/city/city_hyderabad_01.csv
@@ -155,3 +155,4 @@
 ,NaPanta,support@napanta.com,Contact Desk,General,Hyderabad,Hyderabad (Somajiguda); agri-advisory/farm management SaaS app; VERIFIED printed on napanta.com (mailto); MX OK (Zoho)
 ,Thanos Technologies,contact@thanos.in,Contact Desk,General,Hyderabad,Hyderabad (per StartupHyderabad dir); agri-drone & precision-ag tech; VERIFIED printed on thanos.in (mailto); MX OK (Google)
 ,Tutorials Point,media@tutorialspoint.com,Contact Desk,General,Hyderabad,"Hyderabad (Kavuri Hills, Madhapur); ed-content/e-learning platform; VERIFIED printed on tutorialspoint.com/about/contact_us (mailto); MX OK (Google)"
+,360DigiTMG,info@360digitmg.com,Corporate Office,General,Hyderabad,Hyderabad (Madhapur); data-science/AI training & analytics; VERIFIED printed on 360digitmg.com/contact-us (mailto); MX OK (Google)

--- a/industry/city/city_thane_01.csv
+++ b/industry/city/city_thane_01.csv
@@ -1,0 +1,2 @@
+#,Company,Email,Person,Title,City,Notes
+,Appdid Infotech,info@appdid.com,Corporate Office,General,Thane,Thane (Wagle Estate); mobile app/web dev; VERIFIED printed on appdid.com/contact-us (mailto); MX OK (Google)


### PR DESCRIPTION
Adds seven Hyderabad IT companies to `industry/city/city_hyderabad_01.csv` and mirrors them into the `industry/all_emails.csv` master.

Companies: MouriTech, Anblicks, Innominds, Divami Design Labs, mroads, Tvarana, Nvish Solutions.

Each email was confirmed printed on the company's own contact or careers page (mailto or plain text), then MX-checked, matching the verification standard already used for the existing Hyderabad rows. Deduped against what was already in the file, so `careers@anblicks.com` (already present in the master) was not re-added there.

These sit in the report only. They are not wired into any send batch, so nothing goes out to them until batches are regenerated.