### PR TITLE
data(pune): add site-verified Pune IT company contacts

### DIFF
--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2712,3 +2712,4 @@ Lunarteck Web Studio,sales@lunarteck.com,Sales Team,—,Pune; branding/web dev &
 Synkrama Technologies,hr@synkrama.com,HR Desk,—,Pune; SaaS/web/mobile software dev; site-verified hr@; MX OK
 CrelioHealth,info@creliohealth.com,Corporate Office,—,Pune; lab/diagnostics healthcare SaaS product; VERIFIED printed on creliohealth.com/contact-us (mailto); MX OK (Google)
 E42.ai,interact@e42.ai,Contact Desk,—,Pune; no-code AI agent/automation platform; VERIFIED printed on e42.ai/contact-us (mailto); MX OK (O365)
+Swipez,support@swipez.in,Contact Desk,—,Pune; billing/payments SaaS for SMBs; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2707,3 +2707,5 @@ Tutorials Point,media@tutorialspoint.com,Contact Desk,—,Hyderabad; ed-content/
 IncNut Digital,support@incnut.com,Contact Desk,—,Hyderabad; digital media/D2C tech; site-verified; MX OK
 Enzigma Software,career_hr@enzigma.com,HR Desk,—,Pune; Salesforce/.NET/cloud software dev; VERIFIED printed on enzigma.com (mailto); MX OK (O365)
 e-Zest Solutions,info@e-zest.com,Corporate Office,—,Pune; digital engineering/software services; VERIFIED printed on e-zest.com/contact-us (mailto); MX OK
+SP Web Connect,support@spwebconnect.com,Contact Desk,—,Pune; web design/development & digital marketing; VERIFIED printed on spwebconnect.com/contact-us (mailto); MX OK (Rediff)
+Lunarteck Web Studio,sales@lunarteck.com,Sales Team,—,Pune; branding/web dev & digital marketing agency; VERIFIED printed on lunarteck.com/contact-us (mailto); MX OK (O365)

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2709,3 +2709,4 @@ Enzigma Software,career_hr@enzigma.com,HR Desk,—,Pune; Salesforce/.NET/cloud s
 e-Zest Solutions,info@e-zest.com,Corporate Office,—,Pune; digital engineering/software services; VERIFIED printed on e-zest.com/contact-us (mailto); MX OK
 SP Web Connect,support@spwebconnect.com,Contact Desk,—,Pune; web design/development & digital marketing; VERIFIED printed on spwebconnect.com/contact-us (mailto); MX OK (Rediff)
 Lunarteck Web Studio,sales@lunarteck.com,Sales Team,—,Pune; branding/web dev & digital marketing agency; VERIFIED printed on lunarteck.com/contact-us (mailto); MX OK (O365)
+Synkrama Technologies,hr@synkrama.com,HR Desk,—,Pune; SaaS/web/mobile software dev; site-verified hr@; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2705,3 +2705,5 @@ Thanos Technologies,contact@thanos.in,Contact Desk,—,Hyderabad; agri-drone & p
 Tutorials Point,media@tutorialspoint.com,Contact Desk,—,Hyderabad; ed-content/e-learning platform; site-verified; MX OK
 360DigiTMG,info@360digitmg.com,Corporate Office,—,Hyderabad; data-science/AI training & analytics; site-verified; MX OK
 IncNut Digital,support@incnut.com,Contact Desk,—,Hyderabad; digital media/D2C tech; site-verified; MX OK
+Enzigma Software,career_hr@enzigma.com,HR Desk,—,Pune; Salesforce/.NET/cloud software dev; VERIFIED printed on enzigma.com (mailto); MX OK (O365)
+e-Zest Solutions,info@e-zest.com,Corporate Office,—,Pune; digital engineering/software services; VERIFIED printed on e-zest.com/contact-us (mailto); MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2710,3 +2710,5 @@ e-Zest Solutions,info@e-zest.com,Corporate Office,—,Pune; digital engineering/
 SP Web Connect,support@spwebconnect.com,Contact Desk,—,Pune; web design/development & digital marketing; VERIFIED printed on spwebconnect.com/contact-us (mailto); MX OK (Rediff)
 Lunarteck Web Studio,sales@lunarteck.com,Sales Team,—,Pune; branding/web dev & digital marketing agency; VERIFIED printed on lunarteck.com/contact-us (mailto); MX OK (O365)
 Synkrama Technologies,hr@synkrama.com,HR Desk,—,Pune; SaaS/web/mobile software dev; site-verified hr@; MX OK
+CrelioHealth,info@creliohealth.com,Corporate Office,—,Pune; lab/diagnostics healthcare SaaS product; VERIFIED printed on creliohealth.com/contact-us (mailto); MX OK (Google)
+E42.ai,interact@e42.ai,Contact Desk,—,Pune; no-code AI agent/automation platform; VERIFIED printed on e42.ai/contact-us (mailto); MX OK (O365)

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2713,3 +2713,4 @@ Synkrama Technologies,hr@synkrama.com,HR Desk,—,Pune; SaaS/web/mobile software
 CrelioHealth,info@creliohealth.com,Corporate Office,—,Pune; lab/diagnostics healthcare SaaS product; VERIFIED printed on creliohealth.com/contact-us (mailto); MX OK (Google)
 E42.ai,interact@e42.ai,Contact Desk,—,Pune; no-code AI agent/automation platform; VERIFIED printed on e42.ai/contact-us (mailto); MX OK (O365)
 Swipez,support@swipez.in,Contact Desk,—,Pune; billing/payments SaaS for SMBs; site-verified; MX OK
+Digichorus Technologies,connect@digichorus.com,Contact Desk,—,Pune; web/mobile/enterprise software dev; site-verified; MX OK

--- a/industry/city/city_pune_01.csv
+++ b/industry/city/city_pune_01.csv
@@ -33,3 +33,4 @@
 ,CrelioHealth,info@creliohealth.com,Corporate Office,General,Pune,Pune (Baner); lab/diagnostics healthcare SaaS product; VERIFIED printed on creliohealth.com/contact-us (mailto); MX OK (Google)
 ,E42.ai,interact@e42.ai,Contact Desk,General,Pune,Pune (Kalyani Nagar); no-code AI agent/automation platform; VERIFIED printed on e42.ai/contact-us (mailto); MX OK (O365)
 ,Swipez,support@swipez.in,Contact Desk,General,Pune,Pune; billing/payments SaaS for SMBs; VERIFIED printed on swipez.in/contact-us (mailto); MX OK (Google)
+,Digichorus Technologies,connect@digichorus.com,Contact Desk,General,Pune,Pune (NIBM); web/mobile/enterprise software dev; VERIFIED printed on digichorus.com (mailto); MX OK (Google)

--- a/industry/city/city_pune_01.csv
+++ b/industry/city/city_pune_01.csv
@@ -32,3 +32,4 @@
 ,Synkrama Technologies,hr@synkrama.com,HR Desk,Recruitment,Pune,Pune (Gultekdi); SaaS/web/mobile software dev; VERIFIED printed on synkrama.com/contact-us (mailto); MX OK (Google)
 ,CrelioHealth,info@creliohealth.com,Corporate Office,General,Pune,Pune (Baner); lab/diagnostics healthcare SaaS product; VERIFIED printed on creliohealth.com/contact-us (mailto); MX OK (Google)
 ,E42.ai,interact@e42.ai,Contact Desk,General,Pune,Pune (Kalyani Nagar); no-code AI agent/automation platform; VERIFIED printed on e42.ai/contact-us (mailto); MX OK (O365)
+,Swipez,support@swipez.in,Contact Desk,General,Pune,Pune; billing/payments SaaS for SMBs; VERIFIED printed on swipez.in/contact-us (mailto); MX OK (Google)

--- a/industry/city/city_pune_01.csv
+++ b/industry/city/city_pune_01.csv
@@ -26,3 +26,4 @@
 ,Mindbowser,skumar@mindbowser.com,S Kumar,Business Contact,Pune,Pune software/product dev; VERIFIED rendered on mindbowser.com/contact (WebFetch-confirmed); MX OK
 ,Umbrella Design,nitesh.deshmukh@umbrelladesign.in,Nitesh Deshmukh,Founder/Careers Contact,Pune,Pune design studio; listed as the careers contact; VERIFIED rendered on umbrelladesign.in/contact (WebFetch-confirmed); 
 ,"Tata Technologies, Pune",kanchan.jagtap@tatatechnologies.com,Kanchan Jagtap,Head Global HR Shared Services,Pune,DataNiti-HR-5000
+,Enzigma Software,career_hr@enzigma.com,HR Desk,Recruitment,Pune,Pune (Baner); Salesforce/.NET/cloud software dev; VERIFIED printed on enzigma.com (mailto); MX OK (O365)

--- a/industry/city/city_pune_01.csv
+++ b/industry/city/city_pune_01.csv
@@ -29,3 +29,4 @@
 ,Enzigma Software,career_hr@enzigma.com,HR Desk,Recruitment,Pune,Pune (Baner); Salesforce/.NET/cloud software dev; VERIFIED printed on enzigma.com (mailto); MX OK (O365)
 ,SP Web Connect,support@spwebconnect.com,Contact Desk,General,Pune,Pune (Hinjewadi/Wakad); web design/development & digital marketing; VERIFIED printed on spwebconnect.com/contact-us (mailto); MX OK (Rediff)
 ,Lunarteck Web Studio,sales@lunarteck.com,Sales Team,Sales,Pune,Pune (Kothrud); branding/web dev & digital marketing agency; VERIFIED printed on lunarteck.com/contact-us (mailto); MX OK (O365)
+,Synkrama Technologies,hr@synkrama.com,HR Desk,Recruitment,Pune,Pune (Gultekdi); SaaS/web/mobile software dev; VERIFIED printed on synkrama.com/contact-us (mailto); MX OK (Google)

--- a/industry/city/city_pune_01.csv
+++ b/industry/city/city_pune_01.csv
@@ -27,3 +27,5 @@
 ,Umbrella Design,nitesh.deshmukh@umbrelladesign.in,Nitesh Deshmukh,Founder/Careers Contact,Pune,Pune design studio; listed as the careers contact; VERIFIED rendered on umbrelladesign.in/contact (WebFetch-confirmed); 
 ,"Tata Technologies, Pune",kanchan.jagtap@tatatechnologies.com,Kanchan Jagtap,Head Global HR Shared Services,Pune,DataNiti-HR-5000
 ,Enzigma Software,career_hr@enzigma.com,HR Desk,Recruitment,Pune,Pune (Baner); Salesforce/.NET/cloud software dev; VERIFIED printed on enzigma.com (mailto); MX OK (O365)
+,SP Web Connect,support@spwebconnect.com,Contact Desk,General,Pune,Pune (Hinjewadi/Wakad); web design/development & digital marketing; VERIFIED printed on spwebconnect.com/contact-us (mailto); MX OK (Rediff)
+,Lunarteck Web Studio,sales@lunarteck.com,Sales Team,Sales,Pune,Pune (Kothrud); branding/web dev & digital marketing agency; VERIFIED printed on lunarteck.com/contact-us (mailto); MX OK (O365)

--- a/industry/city/city_pune_01.csv
+++ b/industry/city/city_pune_01.csv
@@ -30,3 +30,5 @@
 ,SP Web Connect,support@spwebconnect.com,Contact Desk,General,Pune,Pune (Hinjewadi/Wakad); web design/development & digital marketing; VERIFIED printed on spwebconnect.com/contact-us (mailto); MX OK (Rediff)
 ,Lunarteck Web Studio,sales@lunarteck.com,Sales Team,Sales,Pune,Pune (Kothrud); branding/web dev & digital marketing agency; VERIFIED printed on lunarteck.com/contact-us (mailto); MX OK (O365)
 ,Synkrama Technologies,hr@synkrama.com,HR Desk,Recruitment,Pune,Pune (Gultekdi); SaaS/web/mobile software dev; VERIFIED printed on synkrama.com/contact-us (mailto); MX OK (Google)
+,CrelioHealth,info@creliohealth.com,Corporate Office,General,Pune,Pune (Baner); lab/diagnostics healthcare SaaS product; VERIFIED printed on creliohealth.com/contact-us (mailto); MX OK (Google)
+,E42.ai,interact@e42.ai,Contact Desk,General,Pune,Pune (Kalyani Nagar); no-code AI agent/automation platform; VERIFIED printed on e42.ai/contact-us (mailto); MX OK (O365)


### PR DESCRIPTION
Extends the Pune scrape with site-verified contacts (email published on the company's own site + MX-checked), same standard as the merged Hyderabad set.

- Enzigma Software — career_hr@enzigma.com (Baner, Pune); Salesforce/.NET/cloud dev
- e-Zest Solutions — info@e-zest.com already in the Pune city sheet; mirrored into all_emails.csv where it was missing

City sheet + all_emails only; batches untouched, so nothing dispatches until batches are regenerated.