### PR TITLE
data(singapore): add site-verified Singapore IT company contacts

### DIFF
--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2711,3 +2711,4 @@ Codigo,hello@codigo.co,Contact Desk,—,Singapore; mobile app design & developme
 Verz Design,enquiry@verzdesign.com,Contact Desk,—,Singapore; web design/development & digital marketing; site-verified; MX OK
 JAB Design,info@jab.sg,Corporate Office,—,Singapore; web/app design & development; site-verified; MX OK
 The Digital Experts,info@thedigitalexperts.com.sg,Corporate Office,—,Singapore; web/software dev & IT solutions; site-verified; MX OK
+Construct Digital,info@construct.sg,Corporate Office,—,Singapore; digital/web dev & marketing; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2715,3 +2715,5 @@ Construct Digital,info@construct.sg,Corporate Office,—,Singapore; digital/web 
 Wondertabs,hello@wondertabs.com,Contact Desk,—,Singapore; web/mobile app development; VERIFIED printed on wondertabs.com/contact (mailto); MX OK (Google)
 Digital Business Lab,sgteam@db-lab.com,SG Team,—,"Singapore; digital/social & web dev agency; VERIFIED printed on digital-business-lab.com/contact (mailto, db-lab.com); MX OK"
 NJI Media,info@njimedia.com,Corporate Office,—,Singapore; digital/web dev & creative agency; site-verified; MX OK
+Cleverly,hello@cleverly.sg,Contact Desk,—,Singapore; web design/dev & SEO agency; VERIFIED printed on cleverly.sg/contact (mailto); MX OK (Google)
+Banah,hello@banah.co,Contact Desk,—,Singapore; web/app design & development studio; VERIFIED printed on banah.co/contact (mailto); MX OK (Titan)

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2710,3 +2710,4 @@ Genic Solutions,sales@genicsolutions.com,Sales Team,—,Singapore; software/app 
 Codigo,hello@codigo.co,Contact Desk,—,Singapore; mobile app design & development; site-verified; MX OK
 Verz Design,enquiry@verzdesign.com,Contact Desk,—,Singapore; web design/development & digital marketing; site-verified; MX OK
 JAB Design,info@jab.sg,Corporate Office,—,Singapore; web/app design & development; site-verified; MX OK
+The Digital Experts,info@thedigitalexperts.com.sg,Corporate Office,—,Singapore; web/software dev & IT solutions; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2712,3 +2712,5 @@ Verz Design,enquiry@verzdesign.com,Contact Desk,—,Singapore; web design/develo
 JAB Design,info@jab.sg,Corporate Office,—,Singapore; web/app design & development; site-verified; MX OK
 The Digital Experts,info@thedigitalexperts.com.sg,Corporate Office,—,Singapore; web/software dev & IT solutions; site-verified; MX OK
 Construct Digital,info@construct.sg,Corporate Office,—,Singapore; digital/web dev & marketing; site-verified; MX OK
+Wondertabs,hello@wondertabs.com,Contact Desk,—,Singapore; web/mobile app development; VERIFIED printed on wondertabs.com/contact (mailto); MX OK (Google)
+Digital Business Lab,sgteam@db-lab.com,SG Team,—,"Singapore; digital/social & web dev agency; VERIFIED printed on digital-business-lab.com/contact (mailto, db-lab.com); MX OK"

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2708,3 +2708,4 @@ IncNut Digital,support@incnut.com,Contact Desk,—,Hyderabad; digital media/D2C 
 Vinova,hello@vinova.sg,Contact Desk,—,Singapore; web/mobile app & IT consulting; VERIFIED printed on vinova.sg/contact (mailto); MX OK (O365)
 Genic Solutions,sales@genicsolutions.com,Sales Team,—,Singapore; software/app dev & digital transformation; VERIFIED printed on genicsolutions.com/contact-us (mailto); MX OK (O365)
 Codigo,hello@codigo.co,Contact Desk,—,Singapore; mobile app design & development; site-verified; MX OK
+Verz Design,enquiry@verzdesign.com,Contact Desk,—,Singapore; web design/development & digital marketing; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2709,3 +2709,4 @@ Vinova,hello@vinova.sg,Contact Desk,—,Singapore; web/mobile app & IT consultin
 Genic Solutions,sales@genicsolutions.com,Sales Team,—,Singapore; software/app dev & digital transformation; VERIFIED printed on genicsolutions.com/contact-us (mailto); MX OK (O365)
 Codigo,hello@codigo.co,Contact Desk,—,Singapore; mobile app design & development; site-verified; MX OK
 Verz Design,enquiry@verzdesign.com,Contact Desk,—,Singapore; web design/development & digital marketing; site-verified; MX OK
+JAB Design,info@jab.sg,Corporate Office,—,Singapore; web/app design & development; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2707,3 +2707,4 @@ Tutorials Point,media@tutorialspoint.com,Contact Desk,—,Hyderabad; ed-content/
 IncNut Digital,support@incnut.com,Contact Desk,—,Hyderabad; digital media/D2C tech; site-verified; MX OK
 Vinova,hello@vinova.sg,Contact Desk,—,Singapore; web/mobile app & IT consulting; VERIFIED printed on vinova.sg/contact (mailto); MX OK (O365)
 Genic Solutions,sales@genicsolutions.com,Sales Team,—,Singapore; software/app dev & digital transformation; VERIFIED printed on genicsolutions.com/contact-us (mailto); MX OK (O365)
+Codigo,hello@codigo.co,Contact Desk,—,Singapore; mobile app design & development; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2714,3 +2714,4 @@ The Digital Experts,info@thedigitalexperts.com.sg,Corporate Office,—,Singapore
 Construct Digital,info@construct.sg,Corporate Office,—,Singapore; digital/web dev & marketing; site-verified; MX OK
 Wondertabs,hello@wondertabs.com,Contact Desk,—,Singapore; web/mobile app development; VERIFIED printed on wondertabs.com/contact (mailto); MX OK (Google)
 Digital Business Lab,sgteam@db-lab.com,SG Team,—,"Singapore; digital/social & web dev agency; VERIFIED printed on digital-business-lab.com/contact (mailto, db-lab.com); MX OK"
+NJI Media,info@njimedia.com,Corporate Office,—,Singapore; digital/web dev & creative agency; site-verified; MX OK

--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2705,3 +2705,5 @@ Thanos Technologies,contact@thanos.in,Contact Desk,—,Hyderabad; agri-drone & p
 Tutorials Point,media@tutorialspoint.com,Contact Desk,—,Hyderabad; ed-content/e-learning platform; site-verified; MX OK
 360DigiTMG,info@360digitmg.com,Corporate Office,—,Hyderabad; data-science/AI training & analytics; site-verified; MX OK
 IncNut Digital,support@incnut.com,Contact Desk,—,Hyderabad; digital media/D2C tech; site-verified; MX OK
+Vinova,hello@vinova.sg,Contact Desk,—,Singapore; web/mobile app & IT consulting; VERIFIED printed on vinova.sg/contact (mailto); MX OK (O365)
+Genic Solutions,sales@genicsolutions.com,Sales Team,—,Singapore; software/app dev & digital transformation; VERIFIED printed on genicsolutions.com/contact-us (mailto); MX OK (O365)

--- a/industry/city/city_singapore_01.csv
+++ b/industry/city/city_singapore_01.csv
@@ -6,3 +6,4 @@
 ,Vinova,hello@vinova.sg,Contact Desk,General,Singapore,"Singapore (HQ, Toa Payoh); web/mobile app & IT consulting; VERIFIED printed on vinova.sg/contact (mailto); MX OK (O365)"
 ,Genic Solutions,sales@genicsolutions.com,Sales Team,Sales,Singapore,Singapore (Ubi Techpark); software/app dev & digital transformation; VERIFIED printed on genicsolutions.com/contact-us (mailto); MX OK (O365)
 ,Codigo,hello@codigo.co,Contact Desk,General,Singapore,Singapore (Midview City); mobile app design & development; VERIFIED printed on codigo.co (mailto); MX OK (Google)
+,Verz Design,enquiry@verzdesign.com,Contact Desk,General,Singapore,Singapore (Kallang); web design/development & digital marketing; VERIFIED printed on verzdesign.com/contact-us (mailto); MX OK (Google)

--- a/industry/city/city_singapore_01.csv
+++ b/industry/city/city_singapore_01.csv
@@ -8,3 +8,4 @@
 ,Codigo,hello@codigo.co,Contact Desk,General,Singapore,Singapore (Midview City); mobile app design & development; VERIFIED printed on codigo.co (mailto); MX OK (Google)
 ,Verz Design,enquiry@verzdesign.com,Contact Desk,General,Singapore,Singapore (Kallang); web design/development & digital marketing; VERIFIED printed on verzdesign.com/contact-us (mailto); MX OK (Google)
 ,JAB Design,info@jab.sg,Corporate Office,General,Singapore,"Singapore (Kallang, Vanguard Campus); web/app design & development; VERIFIED printed on jab.sg/contact (mailto); MX OK"
+,The Digital Experts,info@thedigitalexperts.com.sg,Corporate Office,General,Singapore,Singapore (Midview City); web/software dev & IT solutions; VERIFIED printed on thedigitalexperts.com.sg (mailto); MX OK

--- a/industry/city/city_singapore_01.csv
+++ b/industry/city/city_singapore_01.csv
@@ -7,3 +7,4 @@
 ,Genic Solutions,sales@genicsolutions.com,Sales Team,Sales,Singapore,Singapore (Ubi Techpark); software/app dev & digital transformation; VERIFIED printed on genicsolutions.com/contact-us (mailto); MX OK (O365)
 ,Codigo,hello@codigo.co,Contact Desk,General,Singapore,Singapore (Midview City); mobile app design & development; VERIFIED printed on codigo.co (mailto); MX OK (Google)
 ,Verz Design,enquiry@verzdesign.com,Contact Desk,General,Singapore,Singapore (Kallang); web design/development & digital marketing; VERIFIED printed on verzdesign.com/contact-us (mailto); MX OK (Google)
+,JAB Design,info@jab.sg,Corporate Office,General,Singapore,"Singapore (Kallang, Vanguard Campus); web/app design & development; VERIFIED printed on jab.sg/contact (mailto); MX OK"

--- a/industry/city/city_singapore_01.csv
+++ b/industry/city/city_singapore_01.csv
@@ -9,3 +9,4 @@
 ,Verz Design,enquiry@verzdesign.com,Contact Desk,General,Singapore,Singapore (Kallang); web design/development & digital marketing; VERIFIED printed on verzdesign.com/contact-us (mailto); MX OK (Google)
 ,JAB Design,info@jab.sg,Corporate Office,General,Singapore,"Singapore (Kallang, Vanguard Campus); web/app design & development; VERIFIED printed on jab.sg/contact (mailto); MX OK"
 ,The Digital Experts,info@thedigitalexperts.com.sg,Corporate Office,General,Singapore,Singapore (Midview City); web/software dev & IT solutions; VERIFIED printed on thedigitalexperts.com.sg (mailto); MX OK
+,Construct Digital,info@construct.sg,Corporate Office,General,Singapore,"Singapore (Lavender, CT Hub2); digital/web dev & marketing agency; VERIFIED printed on constructdigital.com/contact (mailto, construct.sg); MX OK (Google)"

--- a/industry/city/city_singapore_01.csv
+++ b/industry/city/city_singapore_01.csv
@@ -5,3 +5,4 @@
 ,SINGAPORE LEADS,marie@singaporeleads.com,Marie K,HR And Operation Manager,Singapore,DataNiti-Verified-HR
 ,Vinova,hello@vinova.sg,Contact Desk,General,Singapore,"Singapore (HQ, Toa Payoh); web/mobile app & IT consulting; VERIFIED printed on vinova.sg/contact (mailto); MX OK (O365)"
 ,Genic Solutions,sales@genicsolutions.com,Sales Team,Sales,Singapore,Singapore (Ubi Techpark); software/app dev & digital transformation; VERIFIED printed on genicsolutions.com/contact-us (mailto); MX OK (O365)
+,Codigo,hello@codigo.co,Contact Desk,General,Singapore,Singapore (Midview City); mobile app design & development; VERIFIED printed on codigo.co (mailto); MX OK (Google)

--- a/industry/city/city_singapore_01.csv
+++ b/industry/city/city_singapore_01.csv
@@ -3,3 +3,5 @@
 ,Diaflow,info@diaflow.io,Team,Contact,Singapore,"Growth List Mar-2026 funded co; Singapore, Singapore; Seed; email valid"
 ,Eezee,enquiry@eezee.com.sg,Team,Contact,Singapore,"Growth List Mar-2026 funded co; Singapore, Singapore; raised $5000000.0; Series B; email valid"
 ,SINGAPORE LEADS,marie@singaporeleads.com,Marie K,HR And Operation Manager,Singapore,DataNiti-Verified-HR
+,Vinova,hello@vinova.sg,Contact Desk,General,Singapore,"Singapore (HQ, Toa Payoh); web/mobile app & IT consulting; VERIFIED printed on vinova.sg/contact (mailto); MX OK (O365)"
+,Genic Solutions,sales@genicsolutions.com,Sales Team,Sales,Singapore,Singapore (Ubi Techpark); software/app dev & digital transformation; VERIFIED printed on genicsolutions.com/contact-us (mailto); MX OK (O365)

--- a/industry/city/city_singapore_01.csv
+++ b/industry/city/city_singapore_01.csv
@@ -13,3 +13,5 @@
 ,Wondertabs,hello@wondertabs.com,Contact Desk,General,Singapore,"Singapore (Anson Rd, International Plaza); web/mobile app development; VERIFIED printed on wondertabs.com/contact (mailto); MX OK (Google)"
 ,Digital Business Lab,sgteam@db-lab.com,SG Team,General,Singapore,"Singapore (1 George Street); digital/social & web dev agency; VERIFIED printed on digital-business-lab.com/contact (mailto, db-lab.com); MX OK"
 ,NJI Media,info@njimedia.com,Corporate Office,General,Singapore,Singapore (Cecil St) + DC/London/Doha; digital/web dev & creative agency; VERIFIED printed on njimedia.com/contact (mailto); MX OK (Google)
+,Cleverly,hello@cleverly.sg,Contact Desk,General,Singapore,Singapore (Telok Blangah); web design/dev & SEO agency; VERIFIED printed on cleverly.sg/contact (mailto); MX OK (Google)
+,Banah,hello@banah.co,Contact Desk,General,Singapore,Singapore (Upper Changi); web/app design & development studio; VERIFIED printed on banah.co/contact (mailto); MX OK (Titan)

--- a/industry/city/city_singapore_01.csv
+++ b/industry/city/city_singapore_01.csv
@@ -10,3 +10,5 @@
 ,JAB Design,info@jab.sg,Corporate Office,General,Singapore,"Singapore (Kallang, Vanguard Campus); web/app design & development; VERIFIED printed on jab.sg/contact (mailto); MX OK"
 ,The Digital Experts,info@thedigitalexperts.com.sg,Corporate Office,General,Singapore,Singapore (Midview City); web/software dev & IT solutions; VERIFIED printed on thedigitalexperts.com.sg (mailto); MX OK
 ,Construct Digital,info@construct.sg,Corporate Office,General,Singapore,"Singapore (Lavender, CT Hub2); digital/web dev & marketing agency; VERIFIED printed on constructdigital.com/contact (mailto, construct.sg); MX OK (Google)"
+,Wondertabs,hello@wondertabs.com,Contact Desk,General,Singapore,"Singapore (Anson Rd, International Plaza); web/mobile app development; VERIFIED printed on wondertabs.com/contact (mailto); MX OK (Google)"
+,Digital Business Lab,sgteam@db-lab.com,SG Team,General,Singapore,"Singapore (1 George Street); digital/social & web dev agency; VERIFIED printed on digital-business-lab.com/contact (mailto, db-lab.com); MX OK"

--- a/industry/city/city_singapore_01.csv
+++ b/industry/city/city_singapore_01.csv
@@ -12,3 +12,4 @@
 ,Construct Digital,info@construct.sg,Corporate Office,General,Singapore,"Singapore (Lavender, CT Hub2); digital/web dev & marketing agency; VERIFIED printed on constructdigital.com/contact (mailto, construct.sg); MX OK (Google)"
 ,Wondertabs,hello@wondertabs.com,Contact Desk,General,Singapore,"Singapore (Anson Rd, International Plaza); web/mobile app development; VERIFIED printed on wondertabs.com/contact (mailto); MX OK (Google)"
 ,Digital Business Lab,sgteam@db-lab.com,SG Team,General,Singapore,"Singapore (1 George Street); digital/social & web dev agency; VERIFIED printed on digital-business-lab.com/contact (mailto, db-lab.com); MX OK"
+,NJI Media,info@njimedia.com,Corporate Office,General,Singapore,Singapore (Cecil St) + DC/London/Doha; digital/web dev & creative agency; VERIFIED printed on njimedia.com/contact (mailto); MX OK (Google)


### PR DESCRIPTION
Starts a Singapore city sheet (`industry/city/city_singapore_01.csv`) with site-verified contacts (email published on the company's own site + MX-checked), same standard as the Hyderabad/Pune sets.

- Vinova — hello@vinova.sg (Toa Payoh HQ); web/mobile app & IT consulting
- Genic Solutions — sales@genicsolutions.com (Ubi Techpark); software/app dev

City sheet + all_emails only; batches untouched.