### PR TITLE
career-watch: add 8 recruiters from IIT Bombay/Delhi/Madras/Kanpur + BITS

### DIFF
--- a/industry/career_pages.csv
+++ b/industry/career_pages.csv
@@ -1249,3 +1249,11 @@ Analog Devices,https://careers.analog.com,India,yes,Semiconductor; Bengaluru/Hyd
 Western Digital,https://jobs.smartrecruiters.com/WesternDigital,Bengaluru,yes,Storage; Bengaluru (SPA)
 Applied Materials,https://careers.appliedmaterials.com/careers,India,yes,Semiconductor equip; Bengaluru (SPA)
 Booking.com,https://careers.booking.com/,Bengaluru,yes,Travel-tech; Bengaluru (SPA)
+BlackRock,https://careers.blackrock.com/,India,yes,Fintech/Aladdin eng; Mumbai/Gurugram (SPA) [priority]
+PayU,https://corporate.payu.com/careers/,India,yes,Fintech/payments; Gurugram/Bengaluru (SPA) [priority]
+Paytm,https://paytm.com/careers,India,yes,Fintech product; Noida/Bengaluru (SPA) [priority]
+NPCI,https://www.npci.org.in/careers/current-openings,India,yes,UPI/payments; Mumbai/Chennai/Hyderabad (SPA) [priority]
+Axtria,https://www.axtria.com/careers/,India,yes,Data-analytics software; Noida/Bengaluru (SPA) [priority]
+American Express,https://www.americanexpress.com/en-us/careers/,India,yes,BFSI tech; Gurugram/Bengaluru (SPA) [priority]
+ICICI Bank,https://www.icicicareers.com/,India,yes,BFSI tech cadre; Mumbai/Hyderabad (SPA) [priority]
+HDFC Bank,https://www.hdfcbank.com/personal/about-us/careers,India,yes,BFSI digital/tech; Mumbai/Bengaluru (SPA) [priority]


### PR DESCRIPTION
Adds recruiters pulled from IIT Bombay, Delhi, Madras, Kanpur, and BITS Pilani placement lists.

Most of their top recruiters were already in the watcher (Google, Microsoft, Amazon, Apple, Adobe, Meta, Intel, Qualcomm, NVIDIA, TI, Oracle, IBM, Samsung, Databricks, Rubrik, Flipkart, Meesho, Goldman, Morgan Stanley, JPMorgan, Barclays, Deutsche Bank, Squarepoint, Graviton, Wells Fargo, Bank of America, Mastercard, Bloomberg, Ola, Juspay, EXL). 

### New (8, careers URLs verified to resolve)
BlackRock, PayU, Paytm, NPCI, Axtria, American Express, ICICI Bank, HDFC Bank.

American Express and NPCI 403/404 to a plain request but were confirmed to render (200, with job links) under `RENDER=1` + the browser UA, so they'll be monitored. Off-city ones (Noida/Mumbai/Gurugram) are tagged `[priority]` so the city filter still watches them.
