### PR TITLE
career-watch: add 14 AI/gaming/fintech/SaaS companies

### DIFF
--- a/industry/career_pages.csv
+++ b/industry/career_pages.csv
@@ -1257,3 +1257,17 @@ Axtria,https://www.axtria.com/careers/,India,yes,Data-analytics software; Noida/
 American Express,https://www.americanexpress.com/en-us/careers/,India,yes,BFSI tech; Gurugram/Bengaluru (SPA) [priority]
 ICICI Bank,https://www.icicicareers.com/,India,yes,BFSI tech cadre; Mumbai/Hyderabad (SPA) [priority]
 HDFC Bank,https://www.hdfcbank.com/personal/about-us/careers,India,yes,BFSI digital/tech; Mumbai/Bengaluru (SPA) [priority]
+BharatPe,https://bharatpe.com/careers,India,yes,Fintech; Delhi/Bengaluru (SPA) [priority]
+CleverTap,https://clevertap.com/careers/,Mumbai,yes,MarTech SaaS; Mumbai/Bengaluru (SPA) [priority]
+Gameskraft,https://www.gameskraft.com/careers/,Bengaluru,yes,Gaming; Bengaluru (SPA)
+Gnani.ai,https://www.gnani.ai/careers/,Bengaluru,yes,Voice-AI; Bengaluru (SPA)
+Mobile Premier League,https://www.mpl.live,Bengaluru,yes,Gaming; Bengaluru (SPA)
+Nazara Technologies,https://www.nazara.com/careers,Mumbai,yes,Gaming; Mumbai (SPA) [priority]
+PlaySimple Games,https://playsimple.in,Bengaluru,yes,Gaming; Bengaluru (SPA)
+Qure.ai,https://www.qure.ai,Mumbai,yes,Medical-imaging AI; Mumbai (SPA) [priority]
+Smallcase,https://careers.smallcase.com/,Bengaluru,yes,Fintech; Bengaluru (SPA)
+SuperGaming,https://www.supergaming.com/careers,Pune,yes,Gaming; Pune (SPA)
+Ubisoft India,https://www.ubisoft.com/en-us/company/careers,India,yes,Gaming; Pune/Mumbai (SPA) [priority]
+WinZO,https://www.winzogames.com,India,yes,Gaming; Delhi (SPA) [priority]
+Zupee,https://www.zupee.com,India,yes,Gaming; Gurugram (SPA) [priority]
+Zynga India,https://www.zynga.com/careers/,Bengaluru,yes,Gaming; Bengaluru (SPA)


### PR DESCRIPTION
Broadens the watcher across AI/ML, gaming, fintech, and SaaS — the sectors with companies not already covered.

### New (14, careers URLs verified to resolve)
- **Gaming:** Gameskraft, Mobile Premier League, Nazara, PlaySimple, SuperGaming, Ubisoft India, WinZO, Zupee, Zynga India.
- **AI/ML:** Gnani.ai, Qure.ai.
- **Fintech / SaaS:** BharatPe, CleverTap, Smallcase.

Off-city ones are tagged `[priority]` so the city filter still watches them.

Note: a large share of the sector list was already present — Sarvam AI, Fractal, Kore.ai, Yellow.ai, Haptik, Uniphore, Observe.AI, Mad Street Den (AI); Games24x7, Junglee Games (gaming); Slice, Fi Money, Cashfree, Pine Labs, M2P, Yubi, Perfios, KreditBee (fintech); Zoho, Freshworks, MoEngage, Atlan, Zluri, Innovaccer, Locus.sh (SaaS). So this batch only adds the genuinely-new names.

Watched sources per run: 547 → 569.
