### PR TITLE
emails: consolidate YC email list (400) + start Korea/Japan/Canada sheets

### DIFF
--- a/industry/all_emails.csv
+++ b/industry/all_emails.csv
@@ -2726,3 +2726,10 @@ CrelioHealth,info@creliohealth.com,Corporate Office,—,Pune; lab/diagnostics he
 E42.ai,interact@e42.ai,Contact Desk,—,Pune; no-code AI agent/automation platform; VERIFIED printed on e42.ai/contact-us (mailto); MX OK (O365)
 Swipez,support@swipez.in,Contact Desk,—,Pune; billing/payments SaaS for SMBs; site-verified; MX OK
 Digichorus Technologies,connect@digichorus.com,Contact Desk,—,Pune; web/mobile/enterprise software dev; site-verified; MX OK
+Lunit,apply@lunit.io,Careers team,Contact,VERIFIED published on lunit.io/en/company/contact (apply@); MX OK (Outlook); medical-imaging AI; Seoul
+Upstage,contact@upstage.ai,Team,Contact,VERIFIED published on upstage.ai; MX OK (Google); LLM/document-AI; Seoul
+Allganize,en_biz@allganize.ai,BD team,Contact,VERIFIED published on allganize.ai; MX OK (Google); enterprise LLM; Seoul
+Mathpresso (QANDA),recruit@mathpresso.com,Recruiting,Contact,VERIFIED published on mathpresso.com/en (recruit@); MX OK (Google); edtech AI; Seoul
+Monstarlab,inside_sales@monstar-lab.com,Team,Contact,VERIFIED published on monstar-lab.com/global/contact; MX OK (Google); global dev agency; Tokyo
+Cohere,support@cohere.com,Team,Contact,VERIFIED published on cohere.com footer; MX OK (Proofpoint); LLM/AI; Toronto
+ApplyBoard,help@applyboard.com,Support team,Contact,VERIFIED published on applyboard.com/contact; MX OK (Google); edtech; Kitchener

--- a/industry/city/city_seoul_01.csv
+++ b/industry/city/city_seoul_01.csv
@@ -1,0 +1,5 @@
+#,Company,Email,Person,Title,City,Notes
+,Lunit,apply@lunit.io,Careers team,Contact,Seoul,VERIFIED published on lunit.io/en/company/contact (apply@); MX OK (Outlook); medical-imaging AI
+,Upstage,contact@upstage.ai,Team,Contact,Seoul,VERIFIED published on upstage.ai; MX OK (Google); LLM/document-AI
+,Allganize,en_biz@allganize.ai,BD team,Contact,Seoul,VERIFIED published on allganize.ai; MX OK (Google); enterprise LLM
+,Mathpresso (QANDA),recruit@mathpresso.com,Recruiting,Contact,Seoul,VERIFIED published on mathpresso.com/en (recruit@); MX OK (Google); edtech AI

--- a/industry/city/city_tokyo_01.csv
+++ b/industry/city/city_tokyo_01.csv
@@ -1,0 +1,2 @@
+#,Company,Email,Person,Title,City,Notes
+,Monstarlab,inside_sales@monstar-lab.com,Team,Contact,Tokyo,VERIFIED published on monstar-lab.com/global/contact; MX OK (Google); global dev agency

--- a/industry/city/city_toronto_01.csv
+++ b/industry/city/city_toronto_01.csv
@@ -1,0 +1,3 @@
+#,Company,Email,Person,Title,City,Notes
+,Cohere,support@cohere.com,Team,Contact,Toronto,VERIFIED published on cohere.com footer; MX OK (Proofpoint); LLM/AI
+,ApplyBoard,help@applyboard.com,Support team,Contact,Kitchener,VERIFIED published on applyboard.com/contact; MX OK (Google); edtech

--- a/industry/yc_emails.csv
+++ b/industry/yc_emails.csv
@@ -1,0 +1,401 @@
+Company,Email,Website,Batch,Vertical,Notes
+Adam,founders@adam.new,https://adam.new/,Winter 2025,AI,YC Winter 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Adentris,sales@adentris.com,https://www.adentris.com,Spring 2025,AI,YC Spring 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+AfterQuery,sales@afterquery.com,https://afterquery.com,Winter 2025,AI,YC Winter 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Bloomy,hello@bloomylearning.com,https://bloomylearning.com/,Summer 2026,AI,YC Summer 2026 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Channel3,support@trychannel3.com,https://trychannel3.com,Summer 2025,AI,YC Summer 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Clicks Health,contact@goclicks.ai,https://www.goclicks.ai/,Fall 2025,AI,YC Fall 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Code Four,support@codefour.us,https://codefour.us/,Spring 2025,AI,YC Spring 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Dedalus Labs,support@dedaluslabs.ai,https://www.dedaluslabs.ai/,Summer 2025,AI/DevTools,YC Summer 2025 · AI/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+DeepAware AI (Robotics Center of Silicon Valley),contact@roboticscenter.ai,https://roboticscenter.ai/,Summer 2025,AI/ML,YC Summer 2025 · AI/ML · hiring · cold email for opportunity; ask to forward to hiring manager
+EffiGov,info@effigov.com,https://effigov.com,Summer 2025,AI,YC Summer 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Floot,hello@floot.com,https://floot.com,Summer 2025,AI,YC Summer 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Godela,founders@godela.ai,http://godela.ai,Spring 2025,AI,YC Spring 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Haladir,founders@haladir.com,https://www.haladir.com/,Winter 2026,AI,YC Winter 2026 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Hyperspell,hello@hyperspell.com,https://hyperspell.com,Fall 2025,ML,YC Fall 2025 · ML · hiring · cold email for opportunity; ask to forward to hiring manager
+Layers,hiring@layers.bio,https://www.layers.bio/,Fall 2025,AI,YC Fall 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Lemma,jerry@uselemma.ai,https://www.uselemma.ai/,Fall 2025,AI/DevTools,YC Fall 2025 · AI/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+MadeThis,support@madethis.com,https://madethis.com,Fall 2025,AI,YC Fall 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Nozomio,arlan@nozomio.com,https://www.nozomio.com/,Summer 2025,AI/DevTools,YC Summer 2025 · AI/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+OneStop,support@askonestop.com,https://www.askonestop.com,Summer 2025,AI,YC Summer 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Onlook,contact@onlook.com,https://onlook.com/,Winter 2025,AI/DevTools,YC Winter 2025 · AI/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Ooak Data,contact@ooakdata.com,https://ooakdata.com/,Summer 2026,AI,YC Summer 2026 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Parasma,careers@parasma.com,https://parasma.com,Summer 2026,ML,YC Summer 2026 · ML · hiring · cold email for opportunity; ask to forward to hiring manager
+Parsewise,sales@parsewise.ai,https://parsewise.ai,Spring 2025,AI,YC Spring 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Pelica,founders@pelica.com,https://www.pelica.com/,Spring 2025,AI,YC Spring 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Plexe,hello@plexe.ai,https://plexe.ai,Spring 2025,ML,YC Spring 2025 · ML · hiring · cold email for opportunity; ask to forward to hiring manager
+Proliferate,support@proliferate.com,https://proliferate.com?utm_source=yc&utm_medium=referral&utm_campaign=profile,Summer 2025,AI/DevTools,YC Summer 2025 · AI/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+QualGent,sales@qualgent.ai,https://www.qualgent.ai,Spring 2025,AI,YC Spring 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+RamAIn,founders@ramain.ai,https://ramain.ai,Winter 2026,AI,YC Winter 2026 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Rational,founders@rational.to,https://rational.to,Summer 2026,AI,YC Summer 2026 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Salus,founders@usesalus.ai,https://www.usesalus.ai/,Winter 2026,AI/DevTools,YC Winter 2026 · AI/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Scout,hey@scoutforschools.com,https://scoutforschools.com/,Winter 2025,AI,YC Winter 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Sitefire,info@sitefire.ai,https://sitefire.ai,Winter 2026,AI,YC Winter 2026 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Spott,manu@spott.io,https://spott.io,Winter 2025,AI,YC Winter 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Structured AI,info@getstructured.ai,https://www.getstructured.ai/,Fall 2025,AI,YC Fall 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Superset,founders@superset.sh,https://www.superset.sh/,Spring 2026,AI/DevTools,YC Spring 2026 · AI/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Trata,hello@trytrata.com,https://www.trytrata.com/,Winter 2025,AI,YC Winter 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+a0.dev,founders@a0.dev,https://a0.dev,Winter 2025,AI/DevTools,YC Winter 2025 · AI/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+throxy,pablo@throxy.com,https://throxy.com/,Spring 2025,AI,YC Spring 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+truthsystems,info@truthsystems.ai,https://www.truthsystems.ai,Summer 2025,AI,YC Summer 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Fenrock AI,contact@fenrock.ai,https://fenrock.ai/,Winter 2026,AI,YC Winter 2026 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Piris Labs,contact@pirislabs.io,https://pirislabs.io/,Winter 2026,AI,YC Winter 2026 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+"PerfectBit, Inc.",research@perfectbit.ai,https://perfectbit.ai,Spring 2026,AI/ML,YC Spring 2026 · AI/ML · hiring · cold email for opportunity; ask to forward to hiring manager
+Servo7,pieter@servo7.com,https://servo7.com,Winter 2026,AI,YC Winter 2026 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Simantic,founders@simantic.dev,https://simantic.dev,Fall 2026,DevTools,YC Fall 2026 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Leaping AI,jane@leapingai.com,https://www.leapingai.com,Winter 2025,AI,YC Winter 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+HUD,founders@hud.ai,https://www.hud.ai,Winter 2025,AI,YC Winter 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+DiligenceSquared,founders@diligencesquared.com,https://diligencesquared.com/,Fall 2025,AI,YC Fall 2025 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Theorem,founders@theorem.dev,https://theorem.dev,Spring 2025,ML,YC Spring 2025 · ML · hiring · cold email for opportunity; ask to forward to hiring manager
+Allus AI,contact@allus.ai,https://allus.ai,Fall 2025,ML,YC Fall 2025 · ML · hiring · cold email for opportunity; ask to forward to hiring manager
+cubic,contact@cubic.dev,https://cubic.dev/,Spring 2025,DevTools,YC Spring 2025 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Confident AI,hiring@confident-ai.com,https://confident-ai.com,Winter 2025,DevTools,YC Winter 2025 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Tekton Dynamics,careers@tekton-dynamics.com,https://www.tekton-dynamics.com,Winter 2024,AI,YC Winter 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Scritch,team@scritchai.com,https://www.scritchai.com,Winter 2024,AI,YC Winter 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Pivot Robotics,sales@pivotrobotics.com,https://pivotrobotics.com,Winter 2024,AI,YC Winter 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Duckie,hello@duckie.ai,https://duckie.ai/,Winter 2024,AI,YC Winter 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Momentic,support@momentic.ai,https://momentic.ai,Winter 2024,AI/DevTools,YC Winter 2024 · AI/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Moss,contact@moss.dev,https://moss.dev,Fall 2025,DevTools,YC Fall 2025 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+PointOne,team@pointone.com,https://pointone.com/,Winter 2024,AI,YC Winter 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Andy AI,hello@with-andy.com,https://with-andy.com,Winter 2024,AI,YC Winter 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Maitai,sales@trymaitai.com,https://trymaitai.com,Summer 2024,AI/DevTools,YC Summer 2024 · AI/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Tamarind Bio,info@tamarind.bio,https://www.tamarind.bio,Winter 2024,AI,YC Winter 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+DryMerge,founders@drymerge.com,https://www.drymerge.com,Winter 2024,AI,YC Winter 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Arini,sales@arini.ai,https://www.arini.ai,Winter 2024,AI,YC Winter 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Coval,brooke@coval.dev,https://coval.dev,Summer 2024,AI/DevTools,YC Summer 2024 · AI/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Ellipsis,team@ellipsis.dev,https://ellipsis.dev,Winter 2024,AI/ML/DevTools,YC Winter 2024 · AI/ML/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Educato,info@educato.com,https://www.educato.com/,Summer 2024,AI,YC Summer 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Openbenchmarks,founders@openbenchmarks.com,https://openbenchmarks.com,Fall 2024,AI,YC Fall 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Anthrogen,founders@anthrogen.com,https://anthrogen.com,Summer 2024,AI,YC Summer 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Elevate,hello@useelevate.dev,https://www.useelevate.dev/,Summer 2024,AI,YC Summer 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Overlap,support@overlap.ai,https://www.overlap.ai,Summer 2024,AI,YC Summer 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Assembly HOA,hello@assemblyhoa.com,https://assemblyhoa.com,Summer 2024,AI,YC Summer 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Clearly AI,marketing@clearly-ai.com,https://clearly-ai.com,Summer 2024,AI,YC Summer 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Manufact,founders@manufact.com,https://manufact.com,Summer 2025,DevTools,YC Summer 2025 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Arva AI,hello@arva.ai,https://www.arva.ai,Summer 2024,AI,YC Summer 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Anara,support@anara.com,https://anara.com,Summer 2024,AI,YC Summer 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+x1,founders@x1.new,https://x1.new/,Fall 2024,DevTools,YC Fall 2024 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Zeit AI,contact@zeit-ai.com,https://zeit-ai.com/,Summer 2024,AI,YC Summer 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Rove,support@rove.com,https://rove.com,Winter 2024,AI,YC Winter 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Entangl,info@entangl.com,https://www.entangl.com/,Summer 2024,AI,YC Summer 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Keye,contact@keye.co,https://www.keye.co,Fall 2024,AI,YC Fall 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Ohm,hello@ohm.ai,https://www.ohm.ai,Winter 2023,AI,YC Winter 2023 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+FINNY AI,careers@finny.com,https://www.finny.com/,Summer 2024,ML,YC Summer 2024 · ML · hiring · cold email for opportunity; ask to forward to hiring manager
+Ryvn,founders@ryvn.ai,https://ryvn.ai,Fall 2024,DevTools,YC Fall 2024 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Ocular AI,sales@useocular.com,https://useocular.com,Winter 2024,ML,YC Winter 2024 · ML · hiring · cold email for opportunity; ask to forward to hiring manager
+Silurian,contact@silurian.ai,https://silurian.ai/,Summer 2024,AI,YC Summer 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Spur,contact@spurtest.com,https://www.spurtest.com/,Summer 2024,DevTools,YC Summer 2024 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Respan,careers@respan.ai,https://respan.ai,Winter 2024,DevTools,YC Winter 2024 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Mem0,support@mem0.ai,https://mem0.ai,Summer 2024,DevTools,YC Summer 2024 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+SuperKalam,hello@superkalam.com,https://superkalam.com,Winter 2023,AI,YC Winter 2023 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Glass Health,contact@glass.health,https://glass.health,Winter 2023,AI,YC Winter 2023 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Boundary,vbv@boundaryml.com,https://www.boundaryml.com,Winter 2023,AI/ML/DevTools,YC Winter 2023 · AI/ML/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Berry,sales@berryai.com,https://berryai.com/,Winter 2023,AI,YC Winter 2023 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Unsloth AI,support@unsloth.ai,https://unsloth.ai/,Summer 2024,DevTools,YC Summer 2024 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Vendora,contact@vendora.io,https://www.vendora.io/,Winter 2023,AI,YC Winter 2023 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Silimate,thomas@silimate.com,https://www.silimate.com,Summer 2023,AI/DevTools,YC Summer 2023 · AI/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Sweep,support@sweep.dev,https://sweep.dev/,Summer 2023,AI/DevTools,YC Summer 2023 · AI/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Roame,press@roame.travel,https://roame.travel/,Summer 2023,AI,YC Summer 2023 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Tempo,sales@tempo.new,https://www.tempo.new,Summer 2023,AI/DevTools,YC Summer 2023 · AI/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Subsets,support@subsets.com,https://www.subsets.com,Summer 2023,ML,YC Summer 2023 · ML · hiring · cold email for opportunity; ask to forward to hiring manager
+Morph,info@morphllm.com,https://morphllm.com,Summer 2023,AI/DevTools,YC Summer 2023 · AI/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Kino AI,hello@kino.ai,https://kino.ai,Summer 2023,AI,YC Summer 2023 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Diffuse Bio,info@diffuse.bio,http://diffuse.bio,Winter 2023,ML,YC Winter 2023 · ML · hiring · cold email for opportunity; ask to forward to hiring manager
+IcePanel,mail@icepanel.io,https://icepanel.io,Winter 2023,DevTools,YC Winter 2023 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Frontier Computing,hiring@frontier.site,https://frontier.site,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+FinalDose,founders@finaldose.ai,https://finaldose.ai/,Spring 2026,AI,YC Spring 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Visibl Semiconductors,founders@visiblsemi.com,https://visiblsemi.com,Winter 2026,AI,YC Winter 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+SID,join@sid.ai,https://www.sid.ai,Summer 2023,AI,YC Summer 2023 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Assemble,careers@assemble.ai,https://www.assemble.ai/,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Terminal,careers@withterminal.com,https://www.withterminal.com/,Summer 2023,DevTools,YC Summer 2023 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Ashr,rohan@ashr.io,https://ashr.io,Winter 2026,AI,YC Winter 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Infisical,team@infisical.com,https://infisical.com,Winter 2023,DevTools,YC Winter 2023 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Agentic Fabriq,support@agenticfabriq.com,https://www.agenticfabriq.com,Winter 2026,AI,YC Winter 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Inkeep,support@inkeep.com,https://inkeep.com,Winter 2023,DevTools,YC Winter 2023 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Rimward,careers@rimward.ai,https://rimward.ai/,Summer 2023,ML,YC Summer 2023 · ML · hiring · cold email for opportunity; ask to forward to hiring manager
+Poth Labs,contact@pothlabs.com,https://pothlabs.com,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Twolabs,team@twolabs.ai,https://www.twolabs.ai,Spring 2026,AI,YC Spring 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Collar,hello@usecollarai.com,https://usecollarai.com,Fall 2026,AI,YC Fall 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+rekursiv.ai,contact@rekursiv.ai,https://rekursiv.ai,Summer 2026,AI/ML,YC Summer 2026 · AI/ML · cold email for opportunity; ask to forward to hiring manager
+222,contact@222.place,https://222.place,Winter 2023,ML,YC Winter 2023 · ML · hiring · cold email for opportunity; ask to forward to hiring manager
+Cekura,support@cekura.ai,https://www.cekura.ai/,Fall 2024,DevTools,YC Fall 2024 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Cedana,contact@cedana.ai,https://cedana.ai,Summer 2023,DevTools,YC Summer 2023 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Nowadays,events@nowadays.ai,http://nowadays.ai/,Summer 2023,AI,YC Summer 2023 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Instinct,hello@instinct.xyz,https://instinct.xyz,Winter 2026,AI/ML,YC Winter 2026 · AI/ML · cold email for opportunity; ask to forward to hiring manager
+Datoric,service@datoric.com,https://www.datoric.com,Summer 2026,AI/ML,YC Summer 2026 · AI/ML · cold email for opportunity; ask to forward to hiring manager
+Artie,hi@artie.com,https://www.artie.com/,Summer 2023,DevTools,YC Summer 2023 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Linzumi,hello@linzumi.com,https://linzumi.com,Spring 2026,AI/DevTools,YC Spring 2026 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Omnistrate,careers@omnistrate.com,http://www.omnistrate.com,Winter 2023,DevTools,YC Winter 2023 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Erinys,founders@erinys.ai,https://erinys.ai,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Userlens,hai@userlens.io,https://userlens.io,Spring 2026,AI,YC Spring 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Light Anchor,founders@lightanchor.ai,https://lightanchor.ai,Spring 2026,AI,YC Spring 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Illume Labs,founders@illumelabs.ai,https://www.illumelabs.ai,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Degla Inc,ceo@degla.ai,https://degla.ai,Fall 2026,AI,YC Fall 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Mosaic,contact@mosaic.inc,https://mosaic.inc,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Audun,hello@audun.co,https://audun.co,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Talking Computers,zayaan@talkingcomputers.ai,https://talkingcomputers.ai,Winter 2026,AI,YC Winter 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Palisade,support@palisade.run,https://palisade.run,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Definite,contact@usedefinite.com,https://www.usedefinite.com,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Tenor,adam@heytenor.com,https://heytenor.com/,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Agnost AI,founders@agnost.ai,https://agnost.ai,Summer 2026,AI/ML/DevTools,YC Summer 2026 · AI/ML/DevTools · cold email for opportunity; ask to forward to hiring manager
+Last Accounting Company,hello@lastaccountingcompany.com,https://lastaccountingcompany.com/,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Ekho Labs,contact@ekholabs.com,https://ekholabs.com/,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Perceptron ML,founders@perceptronml.com,https://perceptronml.com,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+hardware intelligence,hi@hardwareintelligence.ai,https://hardwareintelligence.ai,Summer 2026,AI/DevTools,YC Summer 2026 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+herdr,hey@herdr.dev,https://herdr.dev/,Fall 2026,AI/DevTools,YC Fall 2026 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Prized,founders@prized.dev,https://prized.dev,Summer 2026,DevTools,YC Summer 2026 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Armature,founders@armature.tech,https://armature.tech,Spring 2026,AI,YC Spring 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Rex,hello@rex.inc,https://www.rex.inc,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Lantern AI,team@lantern.md,https://www.lantern.md,Fall 2026,AI,YC Fall 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Velum Labs,founders@velum-labs.com,https://www.velum-labs.com/,Winter 2026,ML,YC Winter 2026 · ML · cold email for opportunity; ask to forward to hiring manager
+Stormy,founders@stormy.ai,https://stormy.ai,Summer 2025,AI,YC Summer 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Enjamb Labs,founders@enjamb.ai,https://www.enjamb.ai,Spring 2026,AI,YC Spring 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Riften,info@riften.ai,https://riften.ai,Summer 2026,AI/DevTools,YC Summer 2026 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Belvedir,founders@belvedir.ai,https://belvedir.ai/,Summer 2026,AI/ML,YC Summer 2026 · AI/ML · cold email for opportunity; ask to forward to hiring manager
+Isengard Industries Inc,hello@isengardindustries.com,http://isengardindustries.com/,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Studio,team@trystudio.ai,https://trystudio.ai,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Akon Labs,founders@akonlabs.com,https://akonlabs.com,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Fabraix,founders@fabraix.com,https://fabraix.com,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Vetnio,info@vetnio.com,https://vetnio.com/,Winter 2025,AI,YC Winter 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Inth,support@inth.com,https://inth.com,Spring 2026,DevTools,YC Spring 2026 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Rasyn,founders@rasyn.ai,https://www.rasyn.ai/,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Trope,matthew@trope.ai,https://trope.ai,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Bizmark,rodrigo@bizmark.ai,https://bizmark.ai,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Alkera AI,contact@alkera.ai,https://alkera.ai,Summer 2026,AI/DevTools,YC Summer 2026 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Asteroid,founders@asteroid.ai,https://asteroid.ai,Winter 2025,AI,YC Winter 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Computable,team@getcomputable.com,https://getcomputable.com,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Lucidic AI,team@lucidic.ai,https://lucidic.ai,Winter 2025,AI/DevTools,YC Winter 2025 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Donkey,hello@donkey.trade,https://donkey.trade,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Qlo,founders@getqlo.com,https://www.getqlo.com/,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Arbital,support@arbital.xyz,https://www.arbital.xyz,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+TovenAI,info@toven.ai,https://toven.ai,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Risklytics,hello@risklytics.ai,https://www.risklytics.ai/,Summer 2026,AI/ML,YC Summer 2026 · AI/ML · cold email for opportunity; ask to forward to hiring manager
+Swerve,founders@getswerve.com,https://www.getswerve.com/,Winter 2025,AI,YC Winter 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+neoncoral,stealth@neoncoral.inc,http://neoncoral.inc,Spring 2025,AI,YC Spring 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Marengo,contact@marengox.com,https://marengox.com,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Executor,rhys@executor.sh,https://executor.sh,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Grocalo,support@grocalo.com,https://grocalo.com/,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Cactus Compute,founders@cactuscompute.com,https://www.cactuscompute.com/,Summer 2025,AI/DevTools,YC Summer 2025 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Moving Atoms,founder@movingatoms.ai,https://movingatoms.ai/,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+hiloop,founders@hiloop.ai,https://hiloop.ai,Summer 2026,AI/ML/DevTools,YC Summer 2026 · AI/ML/DevTools · cold email for opportunity; ask to forward to hiring manager
+IRBC,support@irbc.com,https://irbc.com/,Spring 2025,AI,YC Spring 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Financial Datasets,support@financialdatasets.ai,https://financialdatasets.ai/,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Lumeria,contact@lumeria.skin,https://lumeria.skin,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Allia Health,jane@allia.health,https://allia.health/,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Experiential Labs,silen@experientiallabs.ai,https://experientiallabs.ai,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Billow AI Labs,joan@thebillow.ai,https://thebillow.ai/,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Traverse,founders@traverse.so,https://www.traverse.so,Winter 2026,ML,YC Winter 2026 · ML · cold email for opportunity; ask to forward to hiring manager
+Graphify Labs,careers@graphify.com,https://www.graphify.com/,Summer 2026,DevTools,YC Summer 2026 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Waddle Labs,founders@waddlelabs.ai,https://www.waddlelabs.ai/,Summer 2026,DevTools,YC Summer 2026 · DevTools · cold email for opportunity; ask to forward to hiring manager
+PRINCEPS,careers@princeps.dev,https://princeps.dev,Summer 2026,AI/ML,YC Summer 2026 · AI/ML · cold email for opportunity; ask to forward to hiring manager
+Nori,help@nori.ai,https://nori.ai,Fall 2025,AI,YC Fall 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Almanac,rohan@usealmanac.com,https://usealmanac.com,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Hilstart,founders@hilstart.io,https://hilstart.io/,Summer 2026,DevTools,YC Summer 2026 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Design Arena,contact@designarena.ai,https://www.designarena.ai/,Summer 2025,AI,YC Summer 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Maximal,founders@trymaximal.com,https://www.trymaximal.com,Summer 2025,AI,YC Summer 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Agency Tool Company,mailbox@agencytool.com,https://agencytool.com,Summer 2026,DevTools,YC Summer 2026 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Certus AI,info@certus-ai.com,https://www.certus-ai.com/,Summer 2025,AI,YC Summer 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Tweeks.io,contact@tweeks.io,https://tweeks.io,Winter 2025,AI,YC Winter 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Sentient OS,jesai@sentient-os.ai,https://sentient-os.ai,Fall 2026,AI,YC Fall 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Overstand Labs,info@overstandlabs.com,https://overstandlabs.com,Winter 2025,AI,YC Winter 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Speko,team@speko.ai,https://speko.ai/?utm_source=ycombinator&utm_medium=profile,Summer 2026,DevTools,YC Summer 2026 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Zeon Systems,founders@zeonsystems.ai,https://www.zeonsystems.ai/,Spring 2025,AI,YC Spring 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Acolite,team@acolite.ai,https://acolite.ai,Spring 2025,AI,YC Spring 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+CopyCat,hello@runcopycat.com,https://runcopycat.com,Winter 2025,AI,YC Winter 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Exla,contact@exla.ai,https://exla.ai/,Winter 2025,AI,YC Winter 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Tegore,ende@tegore.ai,https://tegore.ai/,Spring 2025,AI,YC Spring 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+StarSling,founders@starsling.dev,https://starsling.dev/,Spring 2025,AI/DevTools,YC Spring 2025 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Magnitude,founders@magnitude.dev,https://magnitude.dev,Summer 2025,AI/DevTools,YC Summer 2025 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Lotas,founders@lotas.ai,https://www.lotas.ai,Summer 2025,AI/DevTools,YC Summer 2025 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Bramante,support@bramantebio.com,https://www.bramantebio.com,Spring 2025,AI,YC Spring 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Cyberdesk,founders@cyberdesk.io,https://www.cyberdesk.io,Summer 2025,AI/DevTools,YC Summer 2025 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Kairos,team@withkairos.co,https://www.withkairos.co/,Spring 2025,AI/ML,YC Spring 2025 · AI/ML · cold email for opportunity; ask to forward to hiring manager
+VibeFlow,founders@vibeflow.ai,https://vibeflow.ai/,Summer 2025,AI/DevTools,YC Summer 2025 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Lyon,founders@lyon.so,https://lyon.so,Summer 2026,ML,YC Summer 2026 · ML · cold email for opportunity; ask to forward to hiring manager
+Bezel,kashyap@trybezel.com,https://www.trybezel.com/,Winter 2025,ML,YC Winter 2025 · ML · cold email for opportunity; ask to forward to hiring manager
+Perseus,careers@perseus.computer,https://perseus.computer,Fall 2025,AI,YC Fall 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Alice.tech,support@alice.tech,https://www.alice.tech/,Winter 2025,AI,YC Winter 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+LogosGuard,hello@logosguard.com,https://logosguard.com/,Fall 2025,AI,YC Fall 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+machine0,support@machine0.io,https://machine0.io,Summer 2026,DevTools,YC Summer 2026 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Redoubt Insurance,andre@redoubt.agency,https://www.redoubt.agency,Fall 2026,AI,YC Fall 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Alter,security@alterauth.com,https://alterauth.com,Summer 2025,DevTools,YC Summer 2025 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Spotlight Realty,support@spotlight.realty,https://www.spotlight.realty,Summer 2025,ML,YC Summer 2025 · ML · cold email for opportunity; ask to forward to hiring manager
+Hoplite,sales@hoplite.sh,https://hoplite.sh,Summer 2026,DevTools,YC Summer 2026 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Doe,jobs@doe.so,https://doe.so/,Summer 2025,AI,YC Summer 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Focal,founders@focalml.com,https://focalml.com,Winter 2024,AI,YC Winter 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Maritime,contact@maritime.sh,https://maritime.sh/,Fall 2026,DevTools,YC Fall 2026 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Omnara,contact@omnara.com,https://omnara.com,Summer 2025,AI/DevTools,YC Summer 2025 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Boost Robotics,founders@boostrobotics.ai,https://www.boostrobotics.ai,Spring 2025,AI,YC Spring 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Clarm,marcus@clarm.com,https://www.clarm.com,Spring 2025,AI,YC Spring 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+assistant-ui,hello@assistant-ui.com,https://assistant-ui.com,Winter 2025,DevTools,YC Winter 2025 · DevTools · cold email for opportunity; ask to forward to hiring manager
+KERNEL,security@kernel.sh,https://www.kernel.sh,Summer 2025,AI/DevTools,YC Summer 2025 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Patent Watch,alex@patentwatch.ai,https://www.patentwatch.ai/,Fall 2025,AI,YC Fall 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Scoop,legal@scooplabs.ai,https://scooplabs.ai,Fall 2025,AI,YC Fall 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Magic Hour,support@magichour.ai,https://magichour.ai,Winter 2024,AI,YC Winter 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Kashikoi,founders@getkashikoi.com,https://www.getkashikoi.com,Spring 2025,ML/DevTools,YC Spring 2025 · ML/DevTools · cold email for opportunity; ask to forward to hiring manager
+Aleph Lab,contact@alephlab.ai,http://alephlab.ai/,Fall 2025,AI,YC Fall 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Tell if AI,team@tellif.ai,https://tellif.ai,Fall 2025,AI,YC Fall 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Philon,info@philon.ai,https://philon.ai/,Fall 2025,AI,YC Fall 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Forge,hello@forgehq.com,https://www.forgehq.com/,Winter 2024,AI,YC Winter 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Pleom,info@pleom.com,https://pleom.com,Summer 2025,AI,YC Summer 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Embedder,founders@embedder.com,https://www.embedder.com,Summer 2025,AI/DevTools,YC Summer 2025 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Boom AI,privacy@useboom.ai,https://useboom.ai,Fall 2025,AI,YC Fall 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Keet,founders@trykeet.com,https://trykeet.com,Summer 2024,AI,YC Summer 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Corsair,dev@corsair.dev,https://www.corsair.dev,Winter 2025,DevTools,YC Winter 2025 · DevTools · cold email for opportunity; ask to forward to hiring manager
+winfunc,hello@winfunc.com,https://winfunc.com,Summer 2024,AI,YC Summer 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Vespper,founders@vespper.com,https://vespper.com/?utm_source=ycombinator.com,Fall 2024,AI/DevTools,YC Fall 2024 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Notte,hello@notte.cc,https://www.notte.cc/,Summer 2025,DevTools,YC Summer 2025 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Moonshine,team@usemoonshine.com,https://usemoonshine.com,Fall 2024,AI/ML,YC Fall 2024 · AI/ML · cold email for opportunity; ask to forward to hiring manager
+ParaQuery,support@paraquery.com,https://paraquery.com,Spring 2025,DevTools,YC Spring 2025 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Alara,support@alaradental.com,http://alaradental.com,Summer 2025,AI,YC Summer 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Freestyle,jobs@freestyle.sh,https://www.freestyle.ai,Fall 2024,AI,YC Summer 2024 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+mlop,founders@mlop.ai,https://mlop.ai,Spring 2025,ML/DevTools,YC Spring 2025 · ML/DevTools · cold email for opportunity; ask to forward to hiring manager
+Specific,careers@specific.dev,https://specific.dev,Fall 2025,DevTools,YC Fall 2025 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Lapis,contact@trylapis.com,https://www.trylapis.com/,Fall 2025,AI,YC Fall 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+ideate.xyz,founders@ideate.xyz,https://ideate.xyz,Summer 2024,DevTools,YC Summer 2024 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Attunement,jane@attunement.ai,http://attunement.ai,Winter 2024,AI,YC Winter 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Gumloop,agent@gumloop.com,https://www.gumloop.com/,Winter 2024,AI,YC Winter 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Alai,founders@getalai.com,https://getalai.com,Winter 2024,AI,YC Winter 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Happenstance,careers@happenstance.ai,https://happenstance.ai,Winter 2024,AI,YC Winter 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Unify,team@unify.ai,https://unify.ai,Winter 2023,AI,YC Winter 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+Voker,support@voker.ai,https://voker.ai,Summer 2024,DevTools,YC Summer 2024 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Downlink,hello@downlink.dev,https://downlink.dev/,Winter 2024,AI/DevTools,YC Winter 2024 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+LemonSlice,founders@lemonslice.com,https://www.lemonslice.com,Winter 2024,AI,YC Winter 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Plume,founders@plumefinder.com,http://www.plumefinder.com,Summer 2024,AI,YC Summer 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Sorcerer,team@sorcerer.earth,https://sorcerer.earth,Summer 2024,AI,YC Summer 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Corgi Labs,woof@corgilabs.ai,https://www.corgilabs.ai,Winter 2023,AI,YC Winter 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+FactIQ,founders@factiq.com,https://factiq.com/,Winter 2023,AI,YC Winter 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+Benchmark,hello@withbenchmark.com,https://withbenchmark.com/,Winter 2023,AI,YC Winter 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+TectoAI,founders@tecto.ai,https://www.tecto.ai/,Summer 2025,AI,YC Summer 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+InspectMind AI,support@inspectmind.ai,https://www.inspectmind.ai,Winter 2024,AI,YC Winter 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Propaya,info@propaya.com,https://www.propaya.com,Summer 2024,AI,YC Summer 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Zavo,hi@zavopay.com,https://zavopay.com,Fall 2025,AI,YC Fall 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Diffusion Studio,contact@diffusion.studio,https://diffusion.studio/,Fall 2024,AI,YC Fall 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Void,hello@useglass.ai,https://useglass.ai,Summer 2024,AI/DevTools,YC Summer 2024 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Freebuff,team@freebuff.com,https://freebuff.com,Fall 2024,AI/DevTools,YC Fall 2024 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Tiptap,humans@tiptap.dev,https://tiptap.dev/,Summer 2023,AI/DevTools,YC Summer 2023 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+TrainLoop,founders@trainloop.ai,http://trainloop.ai,Winter 2025,DevTools,YC Winter 2025 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Lilac,contact@getlilac.com,https://getlilac.com,Summer 2025,ML,YC Summer 2025 · ML · cold email for opportunity; ask to forward to hiring manager
+Twine,john@usetwine.com,http://www.usetwine.com,Summer 2023,AI,YC Summer 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+Vera Health,contact@vera-health.ai,https://www.vera-health.ai,Summer 2024,AI,YC Summer 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Simplex,founders@simplex.sh,https://simplex.sh,Summer 2024,ML,YC Summer 2024 · ML · cold email for opportunity; ask to forward to hiring manager
+The Context Company,founders@thecontextcompany.com,https://www.thecontextcompany.com,Fall 2025,DevTools,YC Fall 2025 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Quetzal,brendan@getquetzal.com,https://getquetzal.com/,Summer 2024,AI,YC Summer 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+vly.ai,team@vly.ai,https://vly.ai,Fall 2024,AI,YC Fall 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Orca Client,support@orcaclient.com,https://orcaclient.com,Summer 2024,AI,YC Summer 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Breez Labs,founders@breezlabs.com,https://www.breezlabs.com/,Winter 2024,AI,YC Winter 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Pierre,pierre@pierre.co,https://pierre.co,Winter 2023,DevTools,YC Winter 2023 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Melder,founders@melder.io,https://melder.io,Fall 2024,AI,YC Fall 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Automorphic,founders@automorphic.ai,https://automorphic.ai/,Summer 2023,DevTools,YC Summer 2023 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Galini,contact@galini.ai,https://www.galini.ai/,Fall 2024,AI,YC Fall 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Pazi,support@pazi.ai,https://pazi.ai/,Winter 2024,DevTools,YC Winter 2024 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Parallel,contact@beparallel.com,https://www.beparallel.com/?utm_source=ycombinator&utm_medium=directory,Winter 2024,AI,YC Winter 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Guide Labs,info@guidelabs.ai,https://www.guidelabs.ai/,Winter 2024,AI,YC Winter 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Veles,simon@getveles.com,http://www.getveles.com,Winter 2024,AI,YC Winter 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+CodeViz,sales@codeviz.ai,https://www.codeviz.ai/,Summer 2024,AI/DevTools,YC Summer 2024 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Hatchet,contact@hatchet.run,https://hatchet.run,Winter 2024,DevTools,YC Winter 2024 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Modus,support@himodus.com,https://himodus.com,Summer 2024,AI,YC Summer 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Hyrex,support@hyrex.io,https://www.hyrex.io,Summer 2024,DevTools,YC Summer 2024 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Redouble AI,info@redouble.ai,https://redouble.ai/,Summer 2024,AI,YC Summer 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Million,founders@million.dev,https://million.dev,Winter 2024,AI,YC Winter 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Undermind,support@undermind.ai,https://www.undermind.ai,Summer 2024,ML,YC Summer 2024 · ML · cold email for opportunity; ask to forward to hiring manager
+Nuanced,ayman@nuanced.dev,https://www.nuanced.dev/,Winter 2024,DevTools,YC Winter 2024 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Polymet,info@polymet.ai,https://polymet.ai,Summer 2024,AI,YC Summer 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Rastro,augustin@rastro.ai,https://rastro.ai,Summer 2024,AI,YC Summer 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Vortexify,support@vortexify.ai,https://www.vortexify.ai,Fall 2024,AI,YC Fall 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Affil.ai,hello@affil.ai,https://affil.ai/,Summer 2024,AI,YC Summer 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+OpenFoundry,hello@openfoundry.ai,https://www.openfoundry.ai/,Winter 2024,DevTools,YC Winter 2024 · DevTools · cold email for opportunity; ask to forward to hiring manager
+AutoPallet Robotics,team@autopallet.bot,https://autopallet.bot,Summer 2024,ML,YC Summer 2024 · ML · cold email for opportunity; ask to forward to hiring manager
+HeroUI,junior@heroui.com,https://heroui.com,Summer 2024,DevTools,YC Summer 2024 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Linum,hello@linum.ai,https://www.linum.ai/,Winter 2023,AI,YC Winter 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+Maxi,support@usemaxi.app,https://www.usemaxi.app,Winter 2023,AI,YC Winter 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+Relvy AI,hello@relvy.ai,https://www.relvy.ai,Fall 2024,DevTools,YC Fall 2024 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Surge,recruiting@surge.app,https://surge.app,Fall 2024,DevTools,YC Fall 2024 · DevTools · cold email for opportunity; ask to forward to hiring manager
+CombineHealth,info@combinehealth.ai,https://www.combinehealth.ai/,Winter 2023,AI/ML,YC Winter 2023 · AI/ML · cold email for opportunity; ask to forward to hiring manager
+AgentCollect,careers@agentcollect.com,https://www.agentcollect.com,Summer 2023,AI,YC Summer 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+Arcimus,hussein@arcimus.com,https://www.arcimus.com/,Summer 2023,AI,YC Summer 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+Reworkd,srijan@reworkd.ai,https://reworkd.ai,Summer 2023,AI,YC Summer 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+Versive,support@getversive.com,https://www.getversive.com/,Winter 2023,AI,YC Winter 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+Dialtone,contact@usedialtone.com,https://usedialtone.com,Summer 2023,AI,YC Summer 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+Wattson Health,privacy@wattsonhealth.com,https://www.wattsonhealth.com,Summer 2023,AI,YC Summer 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+Spine AI,support@getspine.ai,https://www.getspine.ai,Summer 2023,AI,YC Summer 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+Terracotta AI,founders@tryterracotta.com,https://tryterracotta.com,Summer 2023,AI/DevTools,YC Summer 2023 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Slicker,hello@slickerhq.com,https://www.slickerhq.com,Summer 2023,AI,YC Summer 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+Venta AI,info@getventa.ai,https://www.getventa.ai,Summer 2023,AI,YC Summer 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+Trainy,sales@trainy.ai,https://trainy.ai/,Summer 2023,ML/DevTools,YC Summer 2023 · ML/DevTools · cold email for opportunity; ask to forward to hiring manager
+Lightski,founders@lightski.com,https://www.lightski.com,Winter 2023,DevTools,YC Winter 2023 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Persist AI,info@persist-ai.com,http://www.persist-ai.com,Winter 2023,ML,YC Winter 2023 · ML · cold email for opportunity; ask to forward to hiring manager
+rex.fit,hello@rex.fit,https://www.rex.fit,Winter 2023,AI,YC Winter 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+Scanbase,careers@scanbase.com,https://www.scanbase.com,Winter 2023,ML,YC Winter 2023 · ML · cold email for opportunity; ask to forward to hiring manager
+Extend,support@extend.ai,https://www.extend.ai/,Winter 2023,DevTools,YC Winter 2023 · DevTools · cold email for opportunity; ask to forward to hiring manager
+refine,info@refine.dev,https://refine.dev,Summer 2023,DevTools,YC Summer 2023 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Metoro,jobs@metoro.io,https://metoro.io,Summer 2023,DevTools,YC Summer 2023 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Skyhook,careers@skyhook.io,https://skyhook.io,Winter 2023,DevTools,YC Winter 2023 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Depot,help@depot.dev,https://depot.dev,Winter 2023,DevTools,YC Winter 2023 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Conductor Quantum,founders@conductorquantum.com,https://www.conductorquantum.com,Summer 2024,AI/ML,YC Summer 2024 · AI/ML · hiring · cold email for opportunity; ask to forward to hiring manager
+Syntra,support@syntra.com,https://www.syntra.com,Summer 2024,AI,YC Summer 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+The Forecasting Company,work@theforecastingcompany.com,https://www.theforecastingcompany.com,Summer 2024,AI,YC Summer 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+TaxGPT,support@taxgpt.com,https://www.taxgpt.com,Summer 2024,AI,YC Summer 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Innate,axel@innate.bot,https://innate.bot,Fall 2024,AI/DevTools,YC Fall 2024 · AI/DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Elayne,hello@elayne.com,https://www.elayne.com/,Summer 2024,AI,YC Summer 2024 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Thunder Compute,support@thundercompute.com,https://www.thundercompute.com,Summer 2024,DevTools,YC Summer 2024 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+1stCollab,hello@1stcollab.com,https://1stcollab.com/,Winter 2023,AI/ML,YC Winter 2023 · AI/ML · hiring · cold email for opportunity; ask to forward to hiring manager
+Simbie AI,founders@simbie.ai,http://www.simbie.ai,Summer 2023,AI,YC Summer 2023 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Orbio Earth,info@orbio.earth,https://www.orbio.earth/,Summer 2023,AI,YC Summer 2023 · AI · hiring · cold email for opportunity; ask to forward to hiring manager
+Empirical Health,hello@empirical.health,https://empirical.health,Summer 2023,ML,YC Summer 2023 · ML · hiring · cold email for opportunity; ask to forward to hiring manager
+Ndea,contact@ndea.com,https://ndea.com,Winter 2026,AI,YC Winter 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Atlia,founders@atlia.com,https://www.atlia.com,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Zenbu,rob@zenbu.dev,https://www.zenbu.dev/,Spring 2026,AI/DevTools,YC Spring 2026 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Rapidfolio,careers@rapidfolio.com,https://rapidfolio.com/,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+ParadeDB,hello@paradedb.com,https://paradedb.com,Summer 2023,DevTools,YC Summer 2023 · DevTools · hiring · cold email for opportunity; ask to forward to hiring manager
+Kimpton,founders@kimpton.ai,https://kimpton.ai,Spring 2026,AI,YC Spring 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Kebra,founders@kebra.com,https://kebra.com,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Shofo,founders@shofo.ai,https://shofo.ai/,Winter 2026,AI,YC Winter 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Zaplar,founders@zaplar.com,https://zaplar.com,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Stratum Industries,founders@stratumindustries.co,https://stratumindustries.co/,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+DeepReach Inc.,info@deepreach.ai,http://www.deepreach.ai,Summer 2026,AI/ML,YC Summer 2026 · AI/ML · cold email for opportunity; ask to forward to hiring manager
+Agent FM,founders@agentfm.ai,https://www.agentfm.ai/,Summer 2026,AI/DevTools,YC Summer 2026 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Vendo,founders@vendo.run,https://vendo.run/,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Waybill,hello@waybill.to,https://www.waybill.to/,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Simulithic,hello@simulithic.com,https://simulithic.com,Fall 2026,AI,YC Fall 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Decawork,founders@decawork.ai,https://decawork.ai/,Summer 2026,AI,YC Summer 2026 · AI · cold email for opportunity; ask to forward to hiring manager
+Dream,main@pingdream.com,https://www.pingdream.com/,Summer 2026,ML,YC Summer 2026 · ML · cold email for opportunity; ask to forward to hiring manager
+Quantstruct,founders@quantstruct.com,https://quantstruct.com,Winter 2025,AI/DevTools,YC Winter 2025 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Codag,michael@codag.ai,https://codag.ai/,Summer 2026,DevTools,YC Summer 2026 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Inkbox,hello@inkbox.ai,https://inkbox.ai,Summer 2026,DevTools,YC Summer 2026 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Cuckoo Labs,hello@cuckoo.so,https://www.cuckoo.so/,Winter 2025,AI,YC Winter 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Elip AI,gaurav@tryelip.ai,https://www.tryelip.ai/,Winter 2025,AI,YC Winter 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Outlit,hello@outlit.ai,https://outlit.ai/,Winter 2025,AI,YC Winter 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Praxim,contact@praxim.ai,https://www.praxim.ai/,Winter 2025,AI,YC Winter 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+TamLabs,hello@tamlabs.ai,https://tamlabs.ai,Winter 2025,AI,YC Winter 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Harbera,founders@harbera.com,https://harbera.com/,Winter 2025,AI,YC Winter 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Wavedash,contact@wavedash.com,https://wavedash.com,Spring 2025,AI,YC Spring 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Stellon Labs,info@stellonlabs.com,https://stellonlabs.com/,Summer 2025,AI,YC Summer 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Tinfoil,work@tinfoil.sh,https://tinfoil.sh,Spring 2025,AI/DevTools,YC Spring 2025 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Mimos,rohit@trymimos.com,https://www.trymimos.com/,Summer 2025,AI,YC Summer 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Knowlify,info@knowlify.com,https://www.knowlify.com/,Summer 2025,AI,YC Summer 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Monarcha,founders@monarcha.ai,https://monarcha.ai,Summer 2025,AI,YC Summer 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Human Behavior,founders@humanbehavior.co,https://www.humanbehavior.co/,Spring 2025,AI/DevTools,YC Spring 2025 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Helonic,founders@helonic.com,https://helonic.com,Fall 2025,AI,YC Fall 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Mixy,hello@usemixy.com,https://usemixy.com,Fall 2025,AI,YC Fall 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Altur,careers@altur.io,https://altur.io,Summer 2025,AI,YC Summer 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Anto Biosciences,founders@anto.bio,https://www.anto.bio/,Fall 2025,AI,YC Fall 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+CLODO,hello@clodo.ai,https://clodo.ai,Summer 2025,AI,YC Summer 2025 · AI · cold email for opportunity; ask to forward to hiring manager
+Capacitive,contact@capacitive.ai,https://capacitive.ai/,Spring 2025,DevTools,YC Spring 2025 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Greptile,support@greptile.com,https://www.greptile.com,Winter 2024,AI/DevTools,YC Winter 2024 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Okibi,hello@okibi.ai,https://okibi.ai,Summer 2025,DevTools,YC Summer 2025 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Panelytic,founders@panelytic.com,https://panelytic.com/,Winter 2024,AI,YC Winter 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+s2.dev,hi@s2.dev,https://s2.dev,Fall 2025,DevTools,YC Fall 2025 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Diana,careers@getdiana.com,https://getdiana.com/,Winter 2024,AI,YC Winter 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Ångström AI,info@angstrom-ai.com,https://www.angstrom-ai.com,Summer 2024,AI,YC Summer 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+ZeroPath,founders@zeropath.com,https://zeropath.com,Summer 2024,AI/DevTools,YC Summer 2024 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+Riveter,support@riveterhq.com,https://www.riveterhq.com/,Fall 2024,AI,YC Fall 2024 · AI · cold email for opportunity; ask to forward to hiring manager
+Miru,founders@mirurobotics.com,https://www.mirurobotics.com,Summer 2024,DevTools,YC Summer 2024 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Ryse,hello@rysemarket.com,https://www.rysemarket.com/,Winter 2024,ML,YC Winter 2024 · ML · cold email for opportunity; ask to forward to hiring manager
+Struct,team@struct.ai,https://struct.ai,Fall 2024,AI/DevTools,YC Fall 2024 · AI/DevTools · cold email for opportunity; ask to forward to hiring manager
+expand.ai,founder@expand.ai,https://expand.ai/,Summer 2024,DevTools,YC Summer 2024 · DevTools · cold email for opportunity; ask to forward to hiring manager
+Hippo Scribe,hello@gethipposcribe.com,https://gethipposcribe.com,Winter 2023,AI,YC Winter 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+Webhound,team@webhound.ai,https://webhound.ai,Summer 2023,AI,YC Summer 2023 · AI · cold email for opportunity; ask to forward to hiring manager
+cmux,founders@cmux.com,https://www.cmux.com,Summer 2024,DevTools,YC Summer 2024 · DevTools · hiring · from careers page; cold email for opportunity
+Relling,careers@rellingsystems.com,https://relling.co,Summer 2025,AI,YC Summer 2025 · AI · hiring · from careers page; cold email for opportunity
+Artificial Societies,careers@societies.ai,https://societies.io,Winter 2025,AI,YC Winter 2025 · AI · hiring · from careers page; cold email for opportunity


### PR DESCRIPTION
Answers "the YC list has no emails" and starts the Korea/Japan/Canada startup lists.

### YC emails — `industry/yc_emails.csv` (400)
`yc_companies.csv` only had company + website (no email), so the list wasn't usable for outreach. This new file has **400 verified YC company emails** (on-domain founders@/careers@/team@ addresses), each joined to its website/batch/vertical. Columns: `Company,Email,Website,Batch,Vertical,Notes`. Sourced from the already-verified batch_145/146/147 sets, consolidated and de-duplicated into one readable sheet.

### Korea / Japan / Canada startup sheets (site-verified + MX-checked)
Schema `#,Company,Email,Person,Title,City,Notes`:
- **Seoul:** Lunit (apply@lunit.io), Upstage (contact@upstage.ai), Allganize (en_biz@allganize.ai), Mathpresso/QANDA (recruit@mathpresso.com)
- **Tokyo:** Monstarlab (inside_sales@monstar-lab.com)
- **Canada:** Cohere (support@cohere.com), ApplyBoard (help@applyboard.com)

The 7 new rows are mirrored into `all_emails.csv`.

**Reality note:** most KR/JP startups publish a contact *form* (or Cloudflare-obfuscated email), not an address, and almost none publish a *personal* email — so these country sheets are starters. The US side is well covered by the 400 YC emails.
