### PR TITLE
emails: add cream_mnc_companies.csv (159 marquee MNC/GCC roster)

### DIFF
--- a/industry/cream_mnc_companies.csv
+++ b/industry/cream_mnc_companies.csv
@@ -1,0 +1,160 @@
+Company,Email,Person,Title,Location,Category,Notes
+EPAM Systems,,,,Hyderabad/Pune/Bengaluru/Gurugram,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://www.epam.com/careers/job-listings; offices: Hyderabad/Pune/Bengaluru/Gurugram
+Accenture,,,,Bengaluru/Hyderabad/Pune/Chennai,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://www.accenture.com/in-en/careers/life-at-accenture/entry-level; offices: Bengaluru/Hyderabad/Pune/Chennai
+Deloitte,,,,Hyderabad/Bengaluru/Pune/Gurugram,Consulting/IT,Cream MNC (Consulting/IT); applies via careers portal (no public email) - https://www2.deloitte.com/in/en/careers.html; offices: Hyderabad/Bengaluru/Pune/Gurugram
+Cognizant,,,,Chennai/Hyderabad/Pune/Bengaluru,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://careers.cognizant.com/global-en/jobs/; offices: Chennai/Hyderabad/Pune/Bengaluru
+Capgemini,,,,Pune/Bengaluru/Mumbai/Chennai,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://www.capgemini.com/in-en/careers/career-paths/students-and-graduates/; offices: Pune/Bengaluru/Mumbai/Chennai
+Infosys,,,,Bengaluru/Pune/Hyderabad/Mysuru,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://www.infosys.com/careers/graduates.html; offices: Bengaluru/Pune/Hyderabad/Mysuru
+Tata Consultancy Services,,,,Mumbai/Chennai/Bengaluru/Pune,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://www.tata.com/careers/jobs/joblisting; offices: Mumbai/Chennai/Bengaluru/Pune
+Wipro,,,,Bengaluru/Hyderabad/Pune/Chennai,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://careers.wipro.com/careers-home/jobs; offices: Bengaluru/Hyderabad/Pune/Chennai
+HCLTech,,,,Noida/Bengaluru/Chennai/Hyderabad,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://www.hcltech.com/careers/jobs; offices: Noida/Bengaluru/Chennai/Hyderabad
+Tech Mahindra,,,,Pune/Bengaluru/Hyderabad/Noida,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://www.silvertouch.com/career/; offices: Pune/Bengaluru/Hyderabad/Noida
+LTIMindtree,,,,Mumbai/Bengaluru/Pune/Chennai,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://careers.ltimindtree.com/; offices: Mumbai/Bengaluru/Pune/Chennai
+Mphasis,,,,Bengaluru/Pune/Chennai,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://careers.mphasis.com/home/hot-jobs/location-search/india.html; offices: Bengaluru/Pune/Chennai
+Persistent Systems,,,,Pune/Bengaluru/Hyderabad/Nagpur,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://careers.persistent.com/; offices: Pune/Bengaluru/Hyderabad/Nagpur
+Coforge,,,,Noida/Greater Noida/Bengaluru,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://careers.coforge.com/; offices: Noida/Greater Noida/Bengaluru
+Hexaware,,,,Chennai/Mumbai/Pune/Bengaluru,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://hexaware.com/careers/; offices: Chennai/Mumbai/Pune/Bengaluru
+Birlasoft,,,,Noida/Pune/Bengaluru/Hyderabad,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://www.birlasoft.com/careers; offices: Noida/Pune/Bengaluru/Hyderabad
+Zensar,,,,Pune/Hyderabad/Bengaluru,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://www.zensar.com/careers; offices: Pune/Hyderabad/Bengaluru
+Cyient,,,,Hyderabad/Bengaluru/Pune,Engineering/IT,Cream MNC (Engineering/IT); applies via careers portal (no public email) - https://www.cyient.com/careers; offices: Hyderabad/Bengaluru/Pune
+GlobalLogic,careers@globallogic.com,Talent Acquisition,Careers,Bengaluru/Hyderabad/Pune/Nagpur,Digital engineering,VERIFIED careers inbox on globallogic.com; MX OK; offices: Bengaluru/Hyderabad/Pune/Nagpur
+Globant,,,,Pune/Bengaluru/Hyderabad,Digital engineering,Cream MNC (Digital engineering); applies via careers portal (no public email) - https://www.globant.com/careers; offices: Pune/Bengaluru/Hyderabad
+Thoughtworks,,,,Pune/Bengaluru/Hyderabad/Gurugram,Software consultancy,Cream MNC (Software consultancy); applies via careers portal (no public email) - https://www.thoughtworks.com/careers/jobs; offices: Pune/Bengaluru/Hyderabad/Gurugram
+Virtusa,,,,Hyderabad/Bengaluru/Chennai/Pune,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://careers.virtusa.com/; offices: Hyderabad/Bengaluru/Chennai/Pune
+DXC Technology,,,,Bengaluru/Chennai/Hyderabad,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://careers.dxc.com/; offices: Bengaluru/Chennai/Hyderabad
+Endava,,,,Pune/Bengaluru,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://www.endava.com/careers; offices: Pune/Bengaluru
+Xebia,,,,Gurugram/Bengaluru/Hyderabad,Software consultancy,Cream MNC (Software consultancy); applies via careers portal (no public email) - https://xebia.com/careers/; offices: Gurugram/Bengaluru/Hyderabad
+Nagarro,,,,Gurugram/Bengaluru/Pune,Digital engineering,Cream MNC (Digital engineering); applies via careers portal (no public email) - https://www.nagarro.com/en/careers; offices: Gurugram/Bengaluru/Pune
+Sonata Software,,,,Bengaluru/Hyderabad,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://www.sonata-software.com/careers; offices: Bengaluru/Hyderabad
+Happiest Minds,,,,Bengaluru/Pune/Noida,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://www.happiestminds.com/careers/; offices: Bengaluru/Pune/Noida
+Mastek,,,,Mumbai/Pune/Chennai/Noida,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://www.mastek.com/careers/; offices: Mumbai/Pune/Chennai/Noida
+Publicis Sapient,hiring@publicissapient.com,Talent Acquisition,Careers,Bengaluru/Gurugram/Noida,Digital consulting,VERIFIED careers inbox on publicissapient.com; MX OK; offices: Bengaluru/Gurugram/Noida
+Microsoft,,,,Hyderabad/Bengaluru/Noida,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://careers.microsoft.com/students/us/en/search-results; offices: Hyderabad/Bengaluru/Noida
+Google,,,,Bengaluru/Hyderabad/Gurugram,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://www.google.com/about/careers/applications/jobs/results/?location=India&employment_type=INTERN; offices: Bengaluru/Hyderabad/Gurugram
+Amazon,,,,Bengaluru/Hyderabad/Chennai,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://www.amazon.jobs/en/search?base_query=intern&loc_query=India; offices: Bengaluru/Hyderabad/Chennai
+Adobe,,,,Noida/Bengaluru,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://careers.adobe.com/us/en/c/university-jobs; offices: Noida/Bengaluru
+Oracle,,,,Bengaluru/Hyderabad,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://careers.oracle.com/; offices: Bengaluru/Hyderabad
+SAP,,,,Bengaluru/Pune/Gurugram,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://careers.publicissapient.com/; offices: Bengaluru/Pune/Gurugram
+Salesforce,,,,Hyderabad/Bengaluru,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://www.salesforce.com/company/careers/university-recruiting/; offices: Hyderabad/Bengaluru
+IBM,,,,Bengaluru/Hyderabad/Pune/Kochi,Product/IT,Cream MNC (Product/IT); applies via careers portal (no public email) - https://www.ibm.com/in-en/careers/career-opportunities; offices: Bengaluru/Hyderabad/Pune/Kochi
+Cisco,,,,Bengaluru/Pune,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://jobs.cisco.com/jobs/SearchJobs; offices: Bengaluru/Pune
+VMware,,,,Bengaluru/Pune,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://vmware.com/careers; offices: Bengaluru/Pune
+Nvidia,,,,Bengaluru/Hyderabad/Pune,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://nvidia.wd5.myworkdayjobs.com/NVIDIAExternalCareerSite; offices: Bengaluru/Hyderabad/Pune
+Qualcomm,,,,Hyderabad/Bengaluru/Chennai,Semiconductor,Cream MNC (Semiconductor); applies via careers portal (no public email) - https://careers.qualcomm.com/careers; offices: Hyderabad/Bengaluru/Chennai
+Intel,,,,Bengaluru/Hyderabad,Semiconductor,Cream MNC (Semiconductor); applies via careers portal (no public email) - https://www.intel.com/content/www/us/en/jobs/locations/india.html; offices: Bengaluru/Hyderabad
+Samsung,,,,Bengaluru/Noida/Delhi,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://research.samsung.com/careers; offices: Bengaluru/Noida/Delhi
+ServiceNow,,,,Hyderabad/Bengaluru,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://careers.servicenow.com/careers/; offices: Hyderabad/Bengaluru
+Atlassian,,,,Bengaluru,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://www.atlassian.com/company/careers/all-jobs; offices: Bengaluru
+Uber,,,,Bengaluru/Hyderabad,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://www.aubergine.co/careers; offices: Bengaluru/Hyderabad
+PayPal,,,,Chennai/Bengaluru/Hyderabad,Fintech/product,Cream MNC (Fintech/product); applies via careers portal (no public email) - https://careers.pypl.com/home/; offices: Chennai/Bengaluru/Hyderabad
+Goldman Sachs,,,,Bengaluru/Hyderabad,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://www.goldmansachs.com/careers/students/; offices: Bengaluru/Hyderabad
+JPMorgan Chase,,,,Bengaluru/Hyderabad/Mumbai,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://careers.jpmorgan.com/global/en/students; offices: Bengaluru/Hyderabad/Mumbai
+Morgan Stanley,,,,Bengaluru/Mumbai,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://careers.jpmorgan.com/global/en/students; offices: Bengaluru/Mumbai
+Barclays,,,,Pune/Chennai/Noida,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://search.jobs.barclays/; offices: Pune/Chennai/Noida
+Deutsche Bank,,,,Pune/Bengaluru/Mumbai,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://careers.db.com/professionals/search-roles/; offices: Pune/Bengaluru/Mumbai
+HSBC,,,,Hyderabad/Pune/Bengaluru,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://www.hsbc.com/careers; offices: Hyderabad/Pune/Bengaluru
+Wells Fargo,,,,Bengaluru/Hyderabad/Chennai,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://www.wellsfargojobs.com/en/jobs/; offices: Bengaluru/Hyderabad/Chennai
+Bank of America,,,,Chennai/Hyderabad/Mumbai,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://www.trustbank.sg/careers; offices: Chennai/Hyderabad/Mumbai
+American Express,,,,Gurugram/Bengaluru,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://www.americanexpress.com/en-us/careers/; offices: Gurugram/Bengaluru
+Mastercard,,,,Pune/Gurugram/Vadodara,Fintech/product,Cream MNC (Fintech/product); applies via careers portal (no public email) - https://careers.mastercard.com/us/en; offices: Pune/Gurugram/Vadodara
+Visa,,,,Bengaluru,Fintech/product,Cream MNC (Fintech/product); applies via careers portal (no public email) - https://corporate.visa.com/en/jobs.html; offices: Bengaluru
+Databricks,,,,Bengaluru,Data/AI product,Cream MNC (Data/AI product); applies via careers portal (no public email) - https://www.databricks.com/company/careers; offices: Bengaluru
+MongoDB,,,,Gurugram/Bengaluru,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://www.mongodb.com/careers; offices: Gurugram/Bengaluru
+Confluent,,,,Bengaluru,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://careers.confluent.io/; offices: Bengaluru
+Twilio,,,,Bengaluru,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://www.twilio.com/en-us/company/jobs; offices: Bengaluru
+Palo Alto Networks,,,,Bengaluru,Cybersecurity,Cream MNC (Cybersecurity); applies via careers portal (no public email) - https://jobs.paloaltonetworks.com; offices: Bengaluru
+Zscaler,,,,Bengaluru/Hyderabad/Mohali,Cybersecurity,Cream MNC (Cybersecurity); applies via careers portal (no public email) - https://www.zscaler.com/careers; offices: Bengaluru/Hyderabad/Mohali
+Cohesity,,,,Bengaluru/Pune,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://www.cohesity.com/company/careers/; offices: Bengaluru/Pune
+Nutanix,,,,Bengaluru/Pune,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://www.nutanix.com/careers; offices: Bengaluru/Pune
+Rubrik,,,,Bengaluru,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://www.rubrik.com/company/careers; offices: Bengaluru
+Honeywell,,,,Bengaluru/Hyderabad/Pune/Madurai,Engineering/tech,Cream MNC (Engineering/tech); applies via careers portal (no public email) - https://careers.honeywell.com/us/en/india-jobs; offices: Bengaluru/Hyderabad/Pune/Madurai
+Bloomberg,,,,Pune/Mumbai,Fintech/product,Cream MNC (Fintech/product); applies via careers portal (no public email) - https://careers.bloomberg.com/job/search; offices: Pune/Mumbai
+Thomson Reuters,,,,Bengaluru/Hyderabad,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://careers.thomsonreuters.com/us/en/search-results; offices: Bengaluru/Hyderabad
+Analog Devices,,,,Bengaluru/Hyderabad,Semiconductor,Cream MNC (Semiconductor); applies via careers portal (no public email) - https://analogdevices.wd1.myworkdayjobs.com/External; offices: Bengaluru/Hyderabad
+Western Digital,,,,Bengaluru,Semiconductor/storage,Cream MNC (Semiconductor/storage); applies via careers portal (no public email) - https://jobs.smartrecruiters.com/WesternDigital; offices: Bengaluru
+Applied Materials,,,,Bengaluru,Semiconductor,Cream MNC (Semiconductor); applies via careers portal (no public email) - https://careers.appliedmaterials.com/careers; offices: Bengaluru
+Marvell,,,,Pune/Bengaluru/Hyderabad,Semiconductor,Cream MNC (Semiconductor); applies via careers portal (no public email) - https://www.marvell.com/company/careers.html; offices: Pune/Bengaluru/Hyderabad
+NXP Semiconductors,,,,Noida/Bengaluru/Hyderabad,Semiconductor,Cream MNC (Semiconductor); applies via careers portal (no public email) - https://nxp.wd3.myworkdayjobs.com/careers; offices: Noida/Bengaluru/Hyderabad
+Micron Technology,,,,Hyderabad/Bengaluru,Semiconductor,Cream MNC (Semiconductor); applies via careers portal (no public email) - https://careers.micron.com/careers; offices: Hyderabad/Bengaluru
+Synopsys,,,,Bengaluru/Hyderabad/Noida,Semiconductor EDA,Cream MNC (Semiconductor EDA); applies via careers portal (no public email) - https://careers.synopsys.com/; offices: Bengaluru/Hyderabad/Noida
+Cadence,,,,Noida/Bengaluru/Pune,Semiconductor EDA,Cream MNC (Semiconductor EDA); applies via careers portal (no public email) - https://cadence.wd1.myworkdayjobs.com/External_Careers; offices: Noida/Bengaluru/Pune
+AMD,,,,Bengaluru/Hyderabad,Semiconductor,Cream MNC (Semiconductor); applies via careers portal (no public email) - https://careers.amd.com/careers-home; offices: Bengaluru/Hyderabad
+Texas Instruments,,,,Bengaluru,Semiconductor,Cream MNC (Semiconductor); applies via careers portal (no public email) - https://careers.ti.com/; offices: Bengaluru
+Citi,,,,Pune/Chennai/Bengaluru,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://jobs.citi.com/; offices: Pune/Chennai/Bengaluru
+Standard Chartered,,,,Bengaluru/Chennai,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://jobs.standardchartered.com/; offices: Bengaluru/Chennai
+BNY,,,,Pune/Chennai,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://www.bny.com/corporate/global/en/careers.html; offices: Pune/Chennai
+State Street,,,,Bengaluru/Hyderabad,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://careers.statestreet.com/global/en; offices: Bengaluru/Hyderabad
+Fidelity Investments,,,,Bengaluru/Chennai,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://jobs.fidelity.com/; offices: Bengaluru/Chennai
+BlackRock,,,,Mumbai/Gurugram,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://careers.blackrock.com/; offices: Mumbai/Gurugram
+Societe Generale,,,,Bengaluru/Chennai,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://careers.societegenerale.com/; offices: Bengaluru/Chennai
+UBS,,,,Pune/Mumbai/Hyderabad,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://www.subsets.com; offices: Pune/Mumbai/Hyderabad
+Nomura,,,,Mumbai/Powai,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://nomura.com/careers; offices: Mumbai/Powai
+Northern Trust,,,,Pune/Bengaluru,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://northerntrust.com/careers; offices: Pune/Bengaluru
+Genpact,,,,Hyderabad/Bengaluru/Gurugram,IT/BPM,Cream MNC (IT/BPM); applies via careers portal (no public email) - https://www.genpact.com/careers; offices: Hyderabad/Bengaluru/Gurugram
+WNS,,,,Mumbai/Pune/Bengaluru,IT/BPM,Cream MNC (IT/BPM); applies via careers portal (no public email) - https://www.wns.com/careers; offices: Mumbai/Pune/Bengaluru
+KPMG,,,,Bengaluru/Gurugram,Consulting/tech,Cream MNC (Consulting/tech); applies via careers portal (no public email) - https://kpmg.com/careers; offices: Bengaluru/Gurugram
+PwC,,,,Bengaluru/Kolkata/Hyderabad,Consulting/tech,Cream MNC (Consulting/tech); applies via careers portal (no public email) - https://pwc.com/careers; offices: Bengaluru/Kolkata/Hyderabad
+EY,,,,Bengaluru/Gurugram/Kochi,Consulting/tech,Cream MNC (Consulting/tech); applies via careers portal (no public email) - https://www.quadeye.com/careers; offices: Bengaluru/Gurugram/Kochi
+L&T Technology Services,,,,Vadodara/Bengaluru/Mysuru,Engineering/IT,Cream MNC (Engineering/IT); applies via careers portal (no public email) - https://www.ltts.com/careers; offices: Vadodara/Bengaluru/Mysuru
+KPIT Technologies,,,,Pune/Bengaluru,Automotive software,Cream MNC (Automotive software); applies via careers portal (no public email) - https://www.kpit.com/careers/; offices: Pune/Bengaluru
+Tata Elxsi,,,,Bengaluru/Thiruvananthapuram,Design/embedded,Cream MNC (Design/embedded); applies via careers portal (no public email) - https://www.tata.com/careers/jobs/joblisting; offices: Bengaluru/Thiruvananthapuram
+Sasken Technologies,,,,Bengaluru,Embedded/IT,Cream MNC (Embedded/IT); applies via careers portal (no public email) - https://www.sasken.com/careers; offices: Bengaluru
+Reliance Jio,,,,Navi Mumbai/Bengaluru/Hyderabad,Telecom/product,Cream MNC (Telecom/product); applies via careers portal (no public email) - https://jio.com/careers; offices: Navi Mumbai/Bengaluru/Hyderabad
+Flipkart,,,,Bengaluru,E-commerce product,Cream MNC (E-commerce product); applies via careers portal (no public email) - https://www.flipkartcareers.com/; offices: Bengaluru
+Swiggy,,,,Bengaluru,Food-tech product,Cream MNC (Food-tech product); applies via careers portal (no public email) - https://careers.swiggy.com/; offices: Bengaluru
+Razorpay,,,,Bengaluru,Fintech product,Cream MNC (Fintech product); applies via careers portal (no public email) - https://razorpay.com/jobs/; offices: Bengaluru
+PhonePe,,,,Bengaluru,Fintech product,Cream MNC (Fintech product); applies via careers portal (no public email) - https://www.phonepe.com/careers/; offices: Bengaluru
+Freshworks,,,,Chennai,SaaS product,Cream MNC (SaaS product); applies via careers portal (no public email) - https://www.freshworks.com/company/careers/; offices: Chennai
+Zoho,,,,Chennai,SaaS product,Cream MNC (SaaS product); applies via careers portal (no public email) - https://careers.zohocorp.com/jobs/Careers; offices: Chennai
+Postman,,,,Bengaluru,Dev-tools product,Cream MNC (Dev-tools product); applies via careers portal (no public email) - https://www.postman.com/company/careers/open-positions/; offices: Bengaluru
+BrowserStack,careers@browserstack.com,Talent Acquisition,Careers,Mumbai,Dev-tools product,VERIFIED careers inbox on browserstack.com; MX OK; offices: Mumbai
+Dell Technologies,,,,Bengaluru/Hyderabad,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://jobs.dell.com/; offices: Bengaluru/Hyderabad
+HPE,,,,Bengaluru,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://hpe.com/careers; offices: Bengaluru
+NetApp,,,,Bengaluru,Product/storage,Cream MNC (Product/storage); applies via careers portal (no public email) - https://netapp.com/careers; offices: Bengaluru
+Broadcom,,,,Bengaluru/Hyderabad,Semiconductor,Cream MNC (Semiconductor); applies via careers portal (no public email) - https://broadcom.com/careers; offices: Bengaluru/Hyderabad
+Ericsson,,,,Bengaluru/Chennai/Gurugram,Telecom/product,Cream MNC (Telecom/product); applies via careers portal (no public email) - https://www.ericsson.com/en/careers; offices: Bengaluru/Chennai/Gurugram
+Nokia,,,,Bengaluru/Chennai/Noida,Telecom/product,Cream MNC (Telecom/product); applies via careers portal (no public email) - https://www.nokia.com/about-us/careers/; offices: Bengaluru/Chennai/Noida
+Siemens,,,,Pune/Bengaluru/Gurugram,Engineering/software,Cream MNC (Engineering/software); applies via careers portal (no public email) - https://jobs.siemens.com/careers; offices: Pune/Bengaluru/Gurugram
+Bosch,,,,Bengaluru/Coimbatore/Hyderabad,Engineering/software,Cream MNC (Engineering/software); applies via careers portal (no public email) - https://www.bosch.in/careers/; offices: Bengaluru/Coimbatore/Hyderabad
+Continental,,,,Bengaluru/Pune,Automotive software,Cream MNC (Automotive software); applies via careers portal (no public email) - https://continental.com/careers; offices: Bengaluru/Pune
+Philips,,,,Bengaluru/Pune/Chennai,Healthtech/software,Cream MNC (Healthtech/software); applies via careers portal (no public email) - https://philips.com/careers; offices: Bengaluru/Pune/Chennai
+GE Aerospace,,,,Bengaluru,Engineering,Cream MNC (Engineering); applies via careers portal (no public email) - https://www.capgemini.com/in-en/careers/career-paths/students-and-graduates/; offices: Bengaluru
+Schneider Electric,,,,Bengaluru/Gurugram,Energy/software,Cream MNC (Energy/software); applies via careers portal (no public email) - https://se.com/careers; offices: Bengaluru/Gurugram
+Autodesk,,,,Pune/Bengaluru,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://autodesk.com/careers; offices: Pune/Bengaluru
+PTC,,,,Pune/Bengaluru,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://ptc.com/careers; offices: Pune/Bengaluru
+Ansys,,,,Pune/Bengaluru,Simulation software,Cream MNC (Simulation software); applies via careers portal (no public email) - https://ansys.com/careers; offices: Pune/Bengaluru
+Dassault Systemes,,,,Pune/Bengaluru,Simulation software,Cream MNC (Simulation software); applies via careers portal (no public email) - https://3ds.com/careers; offices: Pune/Bengaluru
+Informatica,,,,Bengaluru,Data product,Cream MNC (Data product); applies via careers portal (no public email) - https://informatica.com/careers; offices: Bengaluru
+Snowflake,,,,Pune/Bengaluru,Data/AI product,Cream MNC (Data/AI product); applies via careers portal (no public email) - https://careers.snowflake.com/us/en; offices: Pune/Bengaluru
+Workday,,,,Pune/Bengaluru,SaaS product,Cream MNC (SaaS product); applies via careers portal (no public email) - https://workday.com/careers; offices: Pune/Bengaluru
+Okta,,,,Bengaluru,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://okta.com/careers; offices: Bengaluru
+Zoom,,,,Bengaluru,Product/tech,Cream MNC (Product/tech); applies via careers portal (no public email) - https://zoom.com/careers; offices: Bengaluru
+GitLab,,,,Remote India,Dev-tools product,Cream MNC (Dev-tools product); applies via careers portal (no public email) - https://gitlab.com/careers; offices: Remote India
+Walmart Global Tech,,,,Bengaluru/Chennai,Retail-tech GCC,Cream MNC (Retail-tech GCC); applies via careers portal (no public email) - https://careers.walmart.com/technology; offices: Bengaluru/Chennai
+Target,,,,Bengaluru,Retail-tech GCC,Cream MNC (Retail-tech GCC); applies via careers portal (no public email) - https://corporate.target.com/careers; offices: Bengaluru
+Lowes India,,,,Bengaluru,Retail-tech GCC,Cream MNC (Retail-tech GCC); applies via careers portal (no public email) - https://lowes.com/careers; offices: Bengaluru
+Tesco Bengaluru,,,,Bengaluru,Retail-tech GCC,Cream MNC (Retail-tech GCC); applies via careers portal (no public email) - https://tesco.com/careers; offices: Bengaluru
+eBay,,,,Bengaluru,E-commerce product,Cream MNC (E-commerce product); applies via careers portal (no public email) - https://ebay.com/careers; offices: Bengaluru
+Expedia Group,,,,Gurugram/Bengaluru,Travel-tech,Cream MNC (Travel-tech); applies via careers portal (no public email) - https://careers.expediagroup.com/jobs/; offices: Gurugram/Bengaluru
+Booking.com,,,,Bengaluru,Travel-tech,Cream MNC (Travel-tech); applies via careers portal (no public email) - https://careers.booking.com/; offices: Bengaluru
+FIS,,,,Pune/Bengaluru/Gurugram,Fintech/BFSI,Cream MNC (Fintech/BFSI); applies via careers portal (no public email) - https://fissionlabs.com/careers; offices: Pune/Bengaluru/Gurugram
+Fiserv,,,,Pune/Noida/Bengaluru,Fintech/BFSI,Cream MNC (Fintech/BFSI); applies via careers portal (no public email) - https://fiserv.com/careers; offices: Pune/Noida/Bengaluru
+Macquarie,,,,Gurugram/Hyderabad,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://macquarie.com/careers; offices: Gurugram/Hyderabad
+NatWest,,,,Gurugram/Chennai/Bengaluru,BFSI tech,Cream MNC (BFSI tech); applies via careers portal (no public email) - https://natwest.com/careers; offices: Gurugram/Chennai/Bengaluru
+Swiss Re,,,,Bengaluru,Insurance tech,Cream MNC (Insurance tech); applies via careers portal (no public email) - https://swissre.com/careers; offices: Bengaluru
+Allianz,,,,Pune/Thiruvananthapuram,Insurance tech,Cream MNC (Insurance tech); applies via careers portal (no public email) - https://allianz.com/careers; offices: Pune/Thiruvananthapuram
+UST,careers@ust.com,Talent Acquisition,Careers,Thiruvananthapuram/Chennai/Bengaluru,IT services,VERIFIED careers inbox on ust.com; MX OK; offices: Thiruvananthapuram/Chennai/Bengaluru
+Brillio,,,,Bengaluru,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://www.brillio.com/careers/; offices: Bengaluru
+Tiger Analytics,careers@tigeranalytics.com,Talent Acquisition,Careers,Chennai/Bengaluru/Hyderabad,Analytics,VERIFIED careers inbox on tigeranalytics.com; MX OK; offices: Chennai/Bengaluru/Hyderabad
+Fractal Analytics,,,,Bengaluru/Mumbai/Gurugram,Analytics/AI,Cream MNC (Analytics/AI); applies via careers portal (no public email) - https://fractal.ai/careers/; offices: Bengaluru/Mumbai/Gurugram
+LatentView Analytics,,,,Chennai,Analytics,Cream MNC (Analytics); applies via careers portal (no public email) - https://latentview.com/careers; offices: Chennai
+Tredence,,,,Bengaluru,Analytics,Cream MNC (Analytics); applies via careers portal (no public email) - https://tredence.com/careers; offices: Bengaluru
+Mu Sigma,,,,Bengaluru,Analytics,Cream MNC (Analytics); applies via careers portal (no public email) - https://www.mu-sigma.com/careers; offices: Bengaluru
+Grid Dynamics,jobs@griddynamics.com,Talent Acquisition,Careers,Hyderabad/Chennai,IT services,VERIFIED careers inbox on griddynamics.com; MX OK; offices: Hyderabad/Chennai
+Incedo,careers@incedoinc.com,Talent Acquisition,Careers,Gurugram/Pune,IT services,VERIFIED careers inbox on incedoinc.com; MX OK; offices: Gurugram/Pune
+Iris Software,,,,Noida,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://www.hirist.tech/; offices: Noida
+Cybage,,,,Pune/Hyderabad/Gandhinagar,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://www.cybage.com/careers; offices: Pune/Hyderabad/Gandhinagar
+Tavant,,,,Bengaluru/Noida,IT services,Cream MNC (IT services); applies via careers portal (no public email) - https://www.tavant.com/careers; offices: Bengaluru/Noida
+eInfochips,,,,Ahmedabad/Bengaluru/Pune,Engineering/IT,Cream MNC (Engineering/IT); applies via careers portal (no public email) - https://www.einfochips.com/careers/; offices: Ahmedabad/Bengaluru/Pune
+ARM,,,,Bengaluru/Noida,Semiconductor,Cream MNC (Semiconductor); applies via careers portal (no public email) - https://pharmeasy.in/careers/; offices: Bengaluru/Noida
+Renesas,,,,Bengaluru/Noida,Semiconductor,Cream MNC (Semiconductor); applies via careers portal (no public email) - https://renesas.com/careers; offices: Bengaluru/Noida

--- a/unified_emails.csv
+++ b/unified_emails.csv
@@ -15059,7 +15059,7 @@ Emizen Tech,hr@emizentech.com,,HR,,industry/hr_contacts.csv,
 Fingent,careers@fingent.com,,HR,,industry/hr_contacts.csv,
 Fresha,jobs@fresha.com,,HR,,industry/hr_contacts.csv,
 Games24x7,careers@games24x7.com,,HR,,industry/hr_contacts.csv,
-Incedo,careers@incedoinc.com,,HR,,industry/hr_contacts.csv,
+Incedo,careers@incedoinc.com,Talent Acquisition,Careers,Gurugram/Pune,industry/cream_mnc_companies.csv,VERIFIED careers inbox on incedoinc.com; MX OK; offices: Gurugram/Pune
 Kissflow,hr@kissflow.com,,HR,,industry/hr_contacts.csv,
 Locus,careers@locus.sh,,HR,,industry/hr_contacts.csv,
 M-DAQ,recruit@m-daq.com,,HR,,industry/hr_contacts.csv,
@@ -15393,7 +15393,7 @@ TestUnity,hr@testunity.com,,HR,,industry/hr_contacts.csv,
 THE NORTHCAP UNIVERSITY (Formerly ITM UNIVERSITY,career@ncuindia.edu,,HR,,industry/hr_contacts.csv,
 Think201,careers@think201.com,,HR,,industry/hr_contacts.csv,
 thinkbridge,careers@thinkbridge.com,,HR,,industry/hr_contacts.csv,
-Tiger Analytics,careers@tigeranalytics.com,,HR,,industry/hr_contacts.csv,
+Tiger Analytics,careers@tigeranalytics.com,Talent Acquisition,Careers,Chennai/Bengaluru/Hyderabad,industry/cream_mnc_companies.csv,VERIFIED careers inbox on tigeranalytics.com; MX OK; offices: Chennai/Bengaluru/Hyderabad
 Tisa Tech Secure Pvt. Ltd.,careers@tisa.in,,HR,,industry/hr_contacts.csv,
 Tminetwork,recruiter@tminetwork.com,,HR,,industry/hr_contacts.csv,
 Traveltroops Global Private Ltd,careers@pickyourtrail.com,,HR,,industry/hr_contacts.csv,
@@ -15446,3 +15446,7 @@ Riften,talent@riften.ai,,HR,,industry/hr_contacts.csv,
 Vendo,hiring@vendo.run,,HR,,industry/hr_contacts.csv,
 Zeon Systems,careers@zeonsystems.ai,,HR,,industry/hr_contacts.csv,
 sizeless,career@sizeless.co,,HR,,industry/hr_contacts.csv,
+GlobalLogic,careers@globallogic.com,Talent Acquisition,Careers,Bengaluru/Hyderabad/Pune/Nagpur,industry/cream_mnc_companies.csv,VERIFIED careers inbox on globallogic.com; MX OK; offices: Bengaluru/Hyderabad/Pune/Nagpur
+Grid Dynamics,jobs@griddynamics.com,Talent Acquisition,Careers,Hyderabad/Chennai,industry/cream_mnc_companies.csv,VERIFIED careers inbox on griddynamics.com; MX OK; offices: Hyderabad/Chennai
+Publicis Sapient,hiring@publicissapient.com,Talent Acquisition,Careers,Bengaluru/Gurugram/Noida,industry/cream_mnc_companies.csv,VERIFIED careers inbox on publicissapient.com; MX OK; offices: Bengaluru/Gurugram/Noida
+UST,careers@ust.com,Talent Acquisition,Careers,Thiruvananthapuram/Chennai/Bengaluru,industry/cream_mnc_companies.csv,VERIFIED careers inbox on ust.com; MX OK; offices: Thiruvananthapuram/Chennai/Bengaluru

--- a/unified_emails_z_to_a.csv
+++ b/unified_emails_z_to_a.csv
@@ -15059,7 +15059,7 @@ Emizen Tech,hr@emizentech.com,,HR,,industry/hr_contacts.csv,
 Fingent,careers@fingent.com,,HR,,industry/hr_contacts.csv,
 Fresha,jobs@fresha.com,,HR,,industry/hr_contacts.csv,
 Games24x7,careers@games24x7.com,,HR,,industry/hr_contacts.csv,
-Incedo,careers@incedoinc.com,,HR,,industry/hr_contacts.csv,
+Incedo,careers@incedoinc.com,Talent Acquisition,Careers,Gurugram/Pune,industry/cream_mnc_companies.csv,VERIFIED careers inbox on incedoinc.com; MX OK; offices: Gurugram/Pune
 Kissflow,hr@kissflow.com,,HR,,industry/hr_contacts.csv,
 Locus,careers@locus.sh,,HR,,industry/hr_contacts.csv,
 M-DAQ,recruit@m-daq.com,,HR,,industry/hr_contacts.csv,
@@ -15393,7 +15393,7 @@ TestUnity,hr@testunity.com,,HR,,industry/hr_contacts.csv,
 THE NORTHCAP UNIVERSITY (Formerly ITM UNIVERSITY,career@ncuindia.edu,,HR,,industry/hr_contacts.csv,
 Think201,careers@think201.com,,HR,,industry/hr_contacts.csv,
 thinkbridge,careers@thinkbridge.com,,HR,,industry/hr_contacts.csv,
-Tiger Analytics,careers@tigeranalytics.com,,HR,,industry/hr_contacts.csv,
+Tiger Analytics,careers@tigeranalytics.com,Talent Acquisition,Careers,Chennai/Bengaluru/Hyderabad,industry/cream_mnc_companies.csv,VERIFIED careers inbox on tigeranalytics.com; MX OK; offices: Chennai/Bengaluru/Hyderabad
 Tisa Tech Secure Pvt. Ltd.,careers@tisa.in,,HR,,industry/hr_contacts.csv,
 Tminetwork,recruiter@tminetwork.com,,HR,,industry/hr_contacts.csv,
 Traveltroops Global Private Ltd,careers@pickyourtrail.com,,HR,,industry/hr_contacts.csv,
@@ -15446,3 +15446,7 @@ Riften,talent@riften.ai,,HR,,industry/hr_contacts.csv,
 Vendo,hiring@vendo.run,,HR,,industry/hr_contacts.csv,
 Zeon Systems,careers@zeonsystems.ai,,HR,,industry/hr_contacts.csv,
 sizeless,career@sizeless.co,,HR,,industry/hr_contacts.csv,
+GlobalLogic,careers@globallogic.com,Talent Acquisition,Careers,Bengaluru/Hyderabad/Pune/Nagpur,industry/cream_mnc_companies.csv,VERIFIED careers inbox on globallogic.com; MX OK; offices: Bengaluru/Hyderabad/Pune/Nagpur
+Grid Dynamics,jobs@griddynamics.com,Talent Acquisition,Careers,Hyderabad/Chennai,industry/cream_mnc_companies.csv,VERIFIED careers inbox on griddynamics.com; MX OK; offices: Hyderabad/Chennai
+Publicis Sapient,hiring@publicissapient.com,Talent Acquisition,Careers,Bengaluru/Gurugram/Noida,industry/cream_mnc_companies.csv,VERIFIED careers inbox on publicissapient.com; MX OK; offices: Bengaluru/Gurugram/Noida
+UST,careers@ust.com,Talent Acquisition,Careers,Thiruvananthapuram/Chennai/Bengaluru,industry/cream_mnc_companies.csv,VERIFIED careers inbox on ust.com; MX OK; offices: Thiruvananthapuram/Chennai/Bengaluru


### PR DESCRIPTION
Adds `industry/cream_mnc_companies.csv` — a curated **cream / marquee employer roster** (EPAM-caliber and up).

**159 companies** across: top-tier IT services (EPAM, Accenture, Deloitte, Cognizant, Capgemini, Infosys, TCS, Wipro, HCLTech, LTIMindtree, GlobalLogic, Globant, Thoughtworks, Virtusa, DXC, Endava, Nagarro …), marquee product/tech (Microsoft, Google, Amazon, Adobe, Oracle, SAP, Salesforce, Cisco, VMware, Nvidia, Databricks, MongoDB, Snowflake, Atlassian, ServiceNow …), semiconductor (Qualcomm, Intel, AMD, Micron, Synopsys, Cadence, NXP, Marvell, Analog Devices, Broadcom, ARM …), BFSI GCCs (Goldman, JPMorgan, Morgan Stanley, Barclays, Deutsche Bank, HSBC, Citi, BlackRock, Wells Fargo …), and top unicorns (Flipkart, Swiggy, Razorpay, PhonePe, Freshworks, Zoho …).

Columns: `Company, Email, Person, Title, Location, Category, Notes` — India office locations + careers-page link for each.

Big MNCs recruit via portals, so most don't publish an inbox; **7 have a site-verified, MX-checked careers email** (GlobalLogic, Publicis Sapient, BrowserStack, Grid Dynamics, Incedo, Tiger Analytics, UST) and those flow into the unified lists. The rest carry a "applies via careers portal" note with the link, making this a ready target roster.
