### PR TITLE
emails: +22 YC startup outreach inboxes (site scrape)

### DIFF
--- a/industry/yc_emails.csv
+++ b/industry/yc_emails.csv
@@ -418,3 +418,25 @@ Cardinal Gray,muhammad@cardinalgray.com,https://www.cardinalgray.com/,Summer 202
 VectorShift,contact@vectorshift.ai,https://www.vectorshift.ai,Summer 2023,AI,YC Summer 2023 · AI · scraped from site; MX OK
 Numen,contact@numen.com,https://www.numen.com,Summer 2023,ML,YC Summer 2023 · ML · scraped from site; MX OK
 Pair AI,founders@pairai.com,https://www.pairai.com/,Winter 2023,AI,YC Winter 2023 · AI · scraped from site; MX OK
+/dev/fast,founders@dev.fast,https://dev.fast,Winter 2026,DevTools,Scraped from company site (careers/contact); MX OK
+Archal,founders@archal.ai,https://www.archal.ai/,Summer 2026,AI/DevTools,Scraped from company site (careers/contact); MX OK
+Artisan,hello@artisan.co,https://artisan.co/?utm_source=ycombinator,Winter 2024,AI,Scraped from company site (careers/contact); MX OK
+Carrot Labs,contact@superpenguin.ai,https://superpenguin.ai/,Winter 2026,AI,Scraped from company site (careers/contact); MX OK
+Centauri AI,contact@centauri-ai.tech,https://centauri-ai.tech,Winter 2024,DevTools,Scraped from company site (careers/contact); MX OK
+Compyle,hello@compyle.ai,https://compyle.ai,Fall 2025,AI/DevTools,Scraped from company site (careers/contact); MX OK
+Conifer,contact@conifer.build,https://www.conifer.build,Summer 2026,AI/DevTools,Scraped from company site (careers/contact); MX OK
+Corgi Insurance,hello@corgi.insure,https://corgi.com,Summer 2024,AI,Scraped from company site (careers/contact); MX OK
+Dartboard,info@dartboard.ai,https://dartboard.ai,Winter 2025,AI,Scraped from company site (careers/contact); MX OK
+Datafruit,founders@datafruit.dev,https://datafruit.ai/,Summer 2025,AI,Scraped from company site (careers/contact); MX OK
+Frizzle,hello@frizzle.com,https://www.frizzle.com,Summer 2025,AI,Scraped from company site (careers/contact); MX OK
+Fuse,founders@fuseinsight.com,http://www.fuseinsight.com,Summer 2024,AI,Scraped from company site (careers/contact); MX OK
+Osseus,hello@osseus.ai,https://osseus.ai/,Summer 2026,AI,Scraped from company site (careers/contact); MX OK
+Pinnacle,founders@pinnacle.sh,https://pinnacle.sh/,Summer 2024,DevTools,Scraped from company site (careers/contact); MX OK
+ReJot,founders@rejot.dev,https://rejot.dev,Winter 2025,DevTools,Scraped from company site (careers/contact); MX OK
+RunLocal AI,founders@runlocal.ai,https://runlocal.ai,Summer 2024,AI/DevTools,Scraped from company site (careers/contact); MX OK
+SellRaze,info@sellraze.com,https://sellraze.com,Fall 2025,AI,Scraped from company site (careers/contact); MX OK
+Touchmark,contact@touchmark.ai,https://touchmark.ai,Summer 2026,AI,Scraped from company site (careers/contact); MX OK
+Traceforce,info@traceforce.ai,https://www.traceforce.ai,Summer 2026,AI,Scraped from company site (careers/contact); MX OK
+Woz,info@ozcode.com,https://www.wozcode.com/,Winter 2025,AI,Scraped from company site (careers/contact); MX OK
+Yuma AI,hello@yuma.ai,https://yuma.ai,Winter 2023,AI,Scraped from company site (careers/contact); MX OK
+sizeless,info@sizeless.co,https://www.sizeless.co,Summer 2023,AI,Scraped from company site (careers/contact); MX OK

--- a/unified_emails.csv
+++ b/unified_emails.csv
@@ -15579,3 +15579,25 @@ Target,marsh.fernandaz@target.com,,Senior business partner - HR,,industry/hr_con
 Tata Consultancy Services,salimeda.vaishnavi@tcs.com,,Human resources specialist,,industry/hr_contacts.csv,
 Wipro,prabakaran.sakthivel@wipro.com,,Senior executive human resources,,industry/hr_contacts.csv,
 Zomato,rohit.srivastava@zomato.com,,Human resources executive,,industry/hr_contacts.csv,
+/dev/fast,founders@dev.fast,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Archal,founders@archal.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Artisan,hello@artisan.co,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Carrot Labs,contact@superpenguin.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Centauri AI,contact@centauri-ai.tech,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Compyle,hello@compyle.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Conifer,contact@conifer.build,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Corgi Insurance,hello@corgi.insure,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Dartboard,info@dartboard.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Datafruit,founders@datafruit.dev,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Frizzle,hello@frizzle.com,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Fuse,founders@fuseinsight.com,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Osseus,hello@osseus.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Pinnacle,founders@pinnacle.sh,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+ReJot,founders@rejot.dev,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+RunLocal AI,founders@runlocal.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+SellRaze,info@sellraze.com,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+sizeless,info@sizeless.co,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Touchmark,contact@touchmark.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Traceforce,info@traceforce.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Woz,info@ozcode.com,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Yuma AI,hello@yuma.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK

--- a/unified_emails_z_to_a.csv
+++ b/unified_emails_z_to_a.csv
@@ -15579,3 +15579,25 @@ Target,marsh.fernandaz@target.com,,Senior business partner - HR,,industry/hr_con
 Tata Consultancy Services,salimeda.vaishnavi@tcs.com,,Human resources specialist,,industry/hr_contacts.csv,
 Wipro,prabakaran.sakthivel@wipro.com,,Senior executive human resources,,industry/hr_contacts.csv,
 Zomato,rohit.srivastava@zomato.com,,Human resources executive,,industry/hr_contacts.csv,
+/dev/fast,founders@dev.fast,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Archal,founders@archal.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Artisan,hello@artisan.co,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Carrot Labs,contact@superpenguin.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Centauri AI,contact@centauri-ai.tech,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Compyle,hello@compyle.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Conifer,contact@conifer.build,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Corgi Insurance,hello@corgi.insure,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Dartboard,info@dartboard.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Datafruit,founders@datafruit.dev,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Frizzle,hello@frizzle.com,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Fuse,founders@fuseinsight.com,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Osseus,hello@osseus.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Pinnacle,founders@pinnacle.sh,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+ReJot,founders@rejot.dev,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+RunLocal AI,founders@runlocal.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+SellRaze,info@sellraze.com,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+sizeless,info@sizeless.co,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Touchmark,contact@touchmark.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Traceforce,info@traceforce.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Woz,info@ozcode.com,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Yuma AI,hello@yuma.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK


### PR DESCRIPTION
Scraped the 362 YC companies in yc_companies.csv that had no email yet, over their own careers/contact/about pages. 22 published outreach inboxes (founders@/careers@/hello@/contact@), one per company, all MX-verified and deduped. Appended to yc_emails.csv and both unified lists. Structure check passes; LF.