### PR TITLE
emails: +1 cream-company careers inbox (Dynatrace)

### DIFF
--- a/industry/cream_mnc_companies.csv
+++ b/industry/cream_mnc_companies.csv
@@ -82,7 +82,7 @@ Discover,,,,Bengaluru,Karnataka,BFSI GCC,BFSI GCC; applies via careers portal (n
 Disney (Star India),,,,Bengaluru,Karnataka,Media/tech GCC,Media/tech GCC; applies via careers portal (no public email) - https://disney.com/careers; offices: Bengaluru/Mumbai
 DocuSign,,,,Bengaluru,Karnataka,Tech GCC,Tech GCC; applies via careers portal (no public email) - https://docusign.com/careers; offices: Bengaluru/Chennai
 DXC Technology,,,,Bengaluru,Karnataka,IT services,IT services; applies via careers portal (no public email) - https://careers.dxc.com/; offices: Bengaluru/Chennai/Hyderabad
-Dynatrace,,,,Bengaluru,Karnataka,Tech GCC,Tech GCC; applies via careers portal (no public email) - https://dynatrace.com/careers; offices: Bengaluru
+Dynatrace,careers@dynatrace.com,,,Bengaluru,Karnataka,Tech GCC,Careers/HR inbox from company site; Tech GCC; applies via careers portal (no public email) - https://dynatrace.com/careers; offices: Bengaluru
 eBay,nandita@ebay.com,Team,Contact,Bengaluru,Karnataka,E-commerce product,email nandita@ebay.com from existing repo list (domain match); E-commerce product; applies via careers portal (no public email) - https://ebay.com/careers; offices: Bengaluru
 Elastic,adhish.thite@elastic.co,Team,Contact,Bengaluru,Karnataka,Tech GCC,email adhish.thite@elastic.co from existing repo list (domain match); Tech GCC; applies via careers portal (no public email) - https://elastic.co/careers; offices: Bengaluru
 Elevance Health,,,,Bengaluru,Karnataka,Healthcare GCC,Healthcare GCC; applies via careers portal (no public email) - https://elevancehealth.com/careers; offices: Bengaluru/Gurugram

--- a/industry/hr_contacts.csv
+++ b/industry/hr_contacts.csv
@@ -1910,3 +1910,4 @@ Intuit,Khyati Kiran Sahoo,Talent acquisition consultant,khyati_sahoo@intuit.com,
 Fortinet,Divya Munikrishnappa,Recruiter - R&D,dmunikrishnap@fortinet.com,,Vibe Prospecting (Explorium) named HR contact; Bengaluru; email valid
 Akamai,Divya Sharma,Human resources,divya.sharma@akamai.com,,Vibe Prospecting (Explorium) named HR contact; Bengaluru; email valid
 Autodesk,Sasikanth Jonnada,Senior technical recruiter,sasikanth.jonnada@autodesk.com,,Vibe Prospecting (Explorium) named HR contact; Bengaluru; email valid
+Dynatrace,,,careers@dynatrace.com,,Careers/HR inbox published on company site; MX OK; cream company

--- a/unified_emails.csv
+++ b/unified_emails.csv
@@ -15601,3 +15601,4 @@ Touchmark,contact@touchmark.ai,,,,industry/yc_emails.csv,Scraped from company si
 Traceforce,info@traceforce.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
 Woz,info@ozcode.com,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
 Yuma AI,hello@yuma.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Dynatrace,careers@dynatrace.com,,,Bengaluru,industry/cream_mnc_companies.csv,Careers/HR inbox from company site; Tech GCC; applies via careers portal (no public email) - https://dynatrace.com/careers; offices: Bengaluru

--- a/unified_emails_z_to_a.csv
+++ b/unified_emails_z_to_a.csv
@@ -15601,3 +15601,4 @@ Touchmark,contact@touchmark.ai,,,,industry/yc_emails.csv,Scraped from company si
 Traceforce,info@traceforce.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
 Woz,info@ozcode.com,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
 Yuma AI,hello@yuma.ai,,,,industry/yc_emails.csv,Scraped from company site (careers/contact); MX OK
+Dynatrace,careers@dynatrace.com,,,Bengaluru,industry/cream_mnc_companies.csv,Careers/HR inbox from company site; Tech GCC; applies via careers portal (no public email) - https://dynatrace.com/careers; offices: Bengaluru


### PR DESCRIPTION
Broad HR/careers/campus inbox scrape across every cream-company domain (own domain, MX-verified). Only one net-new after dedup: Dynatrace careers@dynatrace.com (the rest were already in the repo). Appended to hr_contacts.csv, filled the Dynatrace cream row, rebuilt both unified lists. Confirms the cream/MNC tier is essentially tapped for site-published HR inboxes.